### PR TITLE
Add tests for RST rendering

### DIFF
--- a/tests/fixtures/test_rst_003.html
+++ b/tests/fixtures/test_rst_003.html
@@ -1,0 +1,8 @@
+<div id="required-packages">
+<h2>Required packages</h2>
+<p>To run the PyPI software, you need Python 2.5+ and PostgreSQL</p>
+</div>
+<div id="quick-development-setup">
+<h2>Quick development setup</h2>
+<p>Make sure you are sitting</p>
+</div>

--- a/tests/fixtures/test_rst_003.rst
+++ b/tests/fixtures/test_rst_003.rst
@@ -1,0 +1,10 @@
+Required packages
+-----------------
+
+To run the PyPI software, you need Python 2.5+ and PostgreSQL
+
+
+Quick development setup
+-----------------------
+
+Make sure you are sitting

--- a/tests/fixtures/test_rst_004.html
+++ b/tests/fixtures/test_rst_004.html
@@ -1,0 +1,8 @@
+<p>&lt;div id=”required-packages”&gt;
+&lt;h2&gt;Required packages&lt;/h2&gt;
+&lt;p&gt;To run the PyPI software, you need Python 2.5+ and PostgreSQL&lt;/p&gt;
+&lt;/div&gt;
+&lt;div id=”quick-development-setup”&gt;
+&lt;h2&gt;Quick development setup&lt;/h2&gt;
+&lt;p&gt;Make sure you are sitting&lt;/p&gt;
+&lt;/div&gt;</p>

--- a/tests/fixtures/test_rst_004.rst
+++ b/tests/fixtures/test_rst_004.rst
@@ -1,0 +1,8 @@
+<div id="required-packages">
+<h2>Required packages</h2>
+<p>To run the PyPI software, you need Python 2.5+ and PostgreSQL</p>
+</div>
+<div id="quick-development-setup">
+<h2>Quick development setup</h2>
+<p>Make sure you are sitting</p>
+</div>

--- a/tests/fixtures/test_rst_005.html
+++ b/tests/fixtures/test_rst_005.html
@@ -1,0 +1,1 @@
+<p>&lt;a href=”<a rel="nofollow" href="http://mymalicioussite.com/">http://mymalicioussite.com/</a>”&gt;Click here&lt;/a&gt;</p>

--- a/tests/fixtures/test_rst_005.rst
+++ b/tests/fixtures/test_rst_005.rst
@@ -1,0 +1,1 @@
+<a href="http://mymalicioussite.com/">Click here</a>

--- a/tests/fixtures/test_rst_006.html
+++ b/tests/fixtures/test_rst_006.html
@@ -1,0 +1,1 @@
+<p>&lt;iframe src=”<a rel="nofollow" href="http://mymalicioussite.com/">http://mymalicioussite.com/</a>”&gt;Click here&lt;/iframe&gt;</p>

--- a/tests/fixtures/test_rst_006.rst
+++ b/tests/fixtures/test_rst_006.rst
@@ -1,0 +1,1 @@
+<iframe src="http://mymalicioussite.com/">Click here</iframe>

--- a/tests/fixtures/test_rst_007.html
+++ b/tests/fixtures/test_rst_007.html
@@ -1,0 +1,4 @@
+Something naughty this way comes
+&lt;script&gt;
+    alert("Hello");
+&lt;/script&gt;

--- a/tests/fixtures/test_rst_007.rst
+++ b/tests/fixtures/test_rst_007.rst
@@ -1,0 +1,4 @@
+Something naughty this way comes
+<script>
+    alert("Hello");
+</script>

--- a/tests/fixtures/test_rst_008.html
+++ b/tests/fixtures/test_rst_008.html
@@ -1,0 +1,16 @@
+<p>Here is some Python code for a <tt>Dog</tt>:</p>
+<pre><span class="k">class</span> <span class="nc">Dog</span><span class="p">(</span><span class="n">Animal</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">):</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
+
+    <span class="k">def</span> <span class="nf">make_sound</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">print</span><span class="p">(</span><span class="s">'Ruff!'</span><span class="p">)</span>
+
+<span class="n">dog</span> <span class="o">=</span> <span class="n">Dog</span><span class="p">(</span><span class="s">'Fido'</span><span class="p">)</span>
+</pre>
+<p>and then here is some bash:</p>
+<pre><span class="k">if</span> <span class="o">[</span> <span class="s2">"</span><span class="nv">$1</span><span class="s2">"</span> <span class="o">=</span> <span class="s2">"--help"</span> <span class="o">]</span><span class="p">;</span> <span class="k">then</span>
+    <span class="nb">echo</span> <span class="s2">"OK"</span>
+<span class="k">fi</span>
+</pre>
+<p>or click <a rel="nofollow" href="http://www.surveymonkey.com">SurveyMonkey</a></p>

--- a/tests/fixtures/test_rst_008.rst
+++ b/tests/fixtures/test_rst_008.rst
@@ -1,0 +1,22 @@
+Here is some Python code for a ``Dog``:
+
+.. code-block:: python
+
+    class Dog(Animal):
+        def __init__(self, name):
+            self.name = name
+
+        def make_sound(self):
+            print('Ruff!')
+
+    dog = Dog('Fido')
+
+and then here is some bash:
+
+.. code-block:: bash
+
+    if [ "$1" = "--help" ]; then
+        echo "OK"
+    fi
+
+or click `SurveyMonkey <http://www.surveymonkey.com>`_

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -1,0 +1,55 @@
+import codecs
+import os
+
+from readme.rst import render
+
+
+def test_rst_001():
+    assert render('Hello') == ('<p>Hello</p>\n', True)
+
+
+def test_rst_002():
+    assert render('http://mymalicioussite.com/') == (
+        ('<p><a rel="nofollow" href="http://mymalicioussite.com/">' +
+         'http://mymalicioussite.com/</a></p>\n'),
+        True)
+
+
+def test_rst_003():
+    _do_test_with_files('test_rst_003')
+
+
+def test_rst_004():
+    _do_test_with_files('test_rst_004')
+
+
+def test_rst_005():
+    _do_test_with_files('test_rst_005')
+
+
+def test_rst_006():
+    _do_test_with_files('test_rst_006')
+
+
+def test_rst_007():
+    _do_test_with_files('test_rst_007', expected_rendered=False)
+
+
+def test_rst_008():
+    _do_test_with_files('test_rst_008')
+
+
+def _do_test_with_files(test_name, expected_rendered=True):
+    rst_markup = read('{0}.rst'.format(test_name))
+    expected_html = read('{0}.html'.format(test_name))
+
+    out, rendered = render(rst_markup)
+
+    assert rendered == expected_rendered
+    assert out == expected_html
+
+
+def read(fn):
+    path = os.path.join(os.path.dirname(__file__), 'fixtures', fn)
+    with codecs.open(path, encoding='utf-8') as f:
+        return f.read()


### PR DESCRIPTION
```
❯ py.test -v
============================================================================= test session starts ==============================================================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4 -- /Users/marca/python/virtualenvs/readme/bin/python
collected 8 items

tests/test_rst.py::test_rst_001 PASSED
tests/test_rst.py::test_rst_002 PASSED
tests/test_rst.py::test_rst_003 PASSED
tests/test_rst.py::test_rst_004 PASSED
tests/test_rst.py::test_rst_005 PASSED
tests/test_rst.py::test_rst_006 PASSED
tests/test_rst.py::test_rst_007 PASSED
tests/test_rst.py::test_rst_008 PASSED

=========================================================================== 8 passed in 0.48 seconds ===========================================================================
```
