### PR TITLE
Fix RST tests

### DIFF
--- a/tests/fixtures/test_rst_005.html
+++ b/tests/fixtures/test_rst_005.html
@@ -1,1 +1,1 @@
-<p>&lt;a href=”<a rel="nofollow" href="http://mymalicioussite.com/">http://mymalicioussite.com/</a>”&gt;Click here&lt;/a&gt;</p>
+<p>&lt;a href=”<a href="http://mymalicioussite.com/" rel="nofollow">http://mymalicioussite.com/</a>”&gt;Click here&lt;/a&gt;</p>

--- a/tests/fixtures/test_rst_006.html
+++ b/tests/fixtures/test_rst_006.html
@@ -1,1 +1,1 @@
-<p>&lt;iframe src=”<a rel="nofollow" href="http://mymalicioussite.com/">http://mymalicioussite.com/</a>”&gt;Click here&lt;/iframe&gt;</p>
+<p>&lt;iframe src=”<a href="http://mymalicioussite.com/" rel="nofollow">http://mymalicioussite.com/</a>”&gt;Click here&lt;/iframe&gt;</p>

--- a/tests/fixtures/test_rst_008.html
+++ b/tests/fixtures/test_rst_008.html
@@ -13,4 +13,4 @@
     <span class="nb">echo</span> <span class="s2">"OK"</span>
 <span class="k">fi</span>
 </pre>
-<p>or click <a rel="nofollow" href="http://www.surveymonkey.com">SurveyMonkey</a></p>
+<p>or click <a href="http://www.surveymonkey.com" rel="nofollow">SurveyMonkey</a></p>

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -10,7 +10,7 @@ def test_rst_001():
 
 def test_rst_002():
     assert render('http://mymalicioussite.com/') == (
-        ('<p><a rel="nofollow" href="http://mymalicioussite.com/">' +
+        ('<p><a href="http://mymalicioussite.com/" rel="nofollow">' +
          'http://mymalicioussite.com/</a></p>\n'),
         True)
 


### PR DESCRIPTION
The new version of bleach now sorts attributes alphabetically so that the results are deterministic (see
https://github.com/jsocol/bleach/pull/137)

so I had to reverse the order of attributes in the expected HTML.
