### PR TITLE
Fix test failure

### DIFF
--- a/tests/fixtures/test_rst_008.html
+++ b/tests/fixtures/test_rst_008.html
@@ -4,9 +4,9 @@
         <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 
     <span class="k">def</span> <span class="nf">make_sound</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="k">print</span><span class="p">(</span><span class="s">'Ruff!'</span><span class="p">)</span>
+        <span class="k">print</span><span class="p">(</span><span class="s1">'Ruff!'</span><span class="p">)</span>
 
-<span class="n">dog</span> <span class="o">=</span> <span class="n">Dog</span><span class="p">(</span><span class="s">'Fido'</span><span class="p">)</span>
+<span class="n">dog</span> <span class="o">=</span> <span class="n">Dog</span><span class="p">(</span><span class="s1">'Fido'</span><span class="p">)</span>
 </pre>
 <p>and then here is some bash:</p>
 <pre><span class="k">if</span> <span class="o">[</span> <span class="s2">"</span><span class="nv">$1</span><span class="s2">"</span> <span class="o">=</span> <span class="s2">"--help"</span> <span class="o">]</span><span class="p">;</span> <span class="k">then</span>


### PR DESCRIPTION
Fixes the following test failure (e.g.:
https://travis-ci.org/pypa/readme_renderer/jobs/148390785):

```
        if "<" in expected:
>           assert out == expected
E           assert '<p>Here is s...nkey</a></p>\n' == '<p>Here is so...nkey</a></p>\n'
E             Skipping 734 identical leading characters in diff, use -v to show
E             - n class="s1">'Ruff!'</span><span class="p">)</span>
E             ?           -
E             + n class="s">'Ruff!'</span><span class="p">)</span>
E
E             - <span class="n">dog</span> <span class="o">=</span> <span class="n">Dog</span><span class="p">(</span><span class="s1">'Fido'</span><span class="p">)</span>
E             ?                                                                                                                     -
E             + <span class="n">dog</span> <span class="o">=</span> <span class="n">Dog</span><span class="p">(</span><span class="s">'Fido'</span><span class="p">)</span>
E               </pre>
E             Detailed information truncated (6 more lines), use "-vv" to show

tests/test_rst.py:31: AssertionError
```
