### PR TITLE
Docutils update

### DIFF
--- a/readme_renderer/rst.py
+++ b/readme_renderer/rst.py
@@ -45,7 +45,6 @@ class ReadMeHTMLTranslator(HTMLTranslator):
             self.body.pop()
             # add on `img` with attributes
             self.body.append(self.starttag(node, "img", **atts))
-        self.body.append(self.context.pop())
 
 
 SETTINGS = {

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setuptools.setup(
 
     install_requires=[
         "bleach",
-        "docutils",
+        "docutils>=0.13.1",
         "Pygments",
         "six",
     ],

--- a/tests/fixtures/test_rst_008.html
+++ b/tests/fixtures/test_rst_008.html
@@ -4,9 +4,9 @@
         <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 
     <span class="k">def</span> <span class="nf">make_sound</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="k">print</span><span class="p">(</span><span class="s">'Ruff!'</span><span class="p">)</span>
+        <span class="k">print</span><span class="p">(</span><span class="s1">'Ruff!'</span><span class="p">)</span>
 
-<span class="n">dog</span> <span class="o">=</span> <span class="n">Dog</span><span class="p">(</span><span class="s">'Fido'</span><span class="p">)</span>
+<span class="n">dog</span> <span class="o">=</span> <span class="n">Dog</span><span class="p">(</span><span class="s1">'Fido'</span><span class="p">)</span>
 </pre>
 <p>and then here is some bash:</p>
 <pre><span class="k">if</span> <span class="o">[</span> <span class="s2">"</span><span class="nv">$1</span><span class="s2">"</span> <span class="o">=</span> <span class="s2">"--help"</span> <span class="o">]</span><span class="p">;</span> <span class="k">then</span>


### PR DESCRIPTION
This PR fixes breaking changes from the release of `docutils==0.13.1` today.

Specifically, a change was introduced [here](https://sourceforge.net/p/docutils/code/7799) which no longer requires `depart_image` to call `self.body.append(self.context.pop())`. Here's the relevant bit of the diff:

```diff
     def depart_image(self, node):
-        self.body.append(self.context.pop())
+        # self.body.append(self.context.pop())
+        pass
```

Sadly `r7799` doesn't seem to actually fix the `<object>`/`<img>` issue, so we still need `ReadMeHTMLTranslator` it seems.

Since this would be a breaking change, I set the `docutils` dependency to be `>=0.13.1`.

Also, there seemed to be a very small unrelated change to the classes used for syntax highlighting which was causing a test to fail, so I updated the fixture to conform to the actual output.