### PR TITLE
Prefer readthedocs.io instead of readthedocs.org for doc links

### DIFF
--- a/tests/fixtures/test_rst_linkify.html
+++ b/tests/fixtures/test_rst_linkify.html
@@ -39,7 +39,7 @@ archive feeds).  If you find a feed that doesn’t work, <a href="https://github
 </tr>
 <tr><th>Issues:</th><td><a href="https://github.com/tulsawebdevs/django-multi-gtfs/issues" rel="nofollow">https://github.com/tulsawebdevs/django-multi-gtfs/issues</a></td>
 </tr>
-<tr><th>Dev Docs:</th><td><a href="http://multigtfs.readthedocs.org/" rel="nofollow">http://multigtfs.readthedocs.org/</a></td>
+<tr><th>Dev Docs:</th><td><a href="https://multigtfs.readthedocs.io/" rel="nofollow">https://multigtfs.readthedocs.io/</a></td>
 </tr>
 <tr><th>IRC:</th><td><a>irc://irc.freenode.net/tulsawebdevs</a></td>
 </tr>

--- a/tests/fixtures/test_rst_linkify.rst
+++ b/tests/fixtures/test_rst_linkify.rst
@@ -49,7 +49,7 @@ Development
 
 :Code:           https://github.com/tulsawebdevs/django-multi-gtfs
 :Issues:         https://github.com/tulsawebdevs/django-multi-gtfs/issues
-:Dev Docs:       http://multigtfs.readthedocs.org/
+:Dev Docs:       https://multigtfs.readthedocs.io/
 :IRC:            irc://irc.freenode.net/tulsawebdevs
 
 


### PR DESCRIPTION
Read the Docs moved to hosting to readthedocs.io instead of readthedocs.org.
Fix all links in the project.

For additional details, see:

https://blog.readthedocs.com/securing-subdomains/

> Starting today, Read the Docs will start hosting projects from subdomains on
> the domain readthedocs.io, instead of on readthedocs.org. This change
> addresses some security concerns around site cookies while hosting user
> generated data on the same domain as our dashboard.