### PR TITLE
Handle invalid address errors

### DIFF
--- a/readme_renderer/clean.py
+++ b/readme_renderer/clean.py
@@ -75,6 +75,8 @@ def clean(html, tags=None, attributes=None, styles=None):
             ),
         ],
     )
-    cleaned = cleaner.clean(html)
-
-    return cleaned
+    try:
+        cleaned = cleaner.clean(html)
+        return cleaned
+    except ValueError:
+        return None

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,0 +1,5 @@
+from readme_renderer.clean import clean
+
+
+def test_invalid_link():
+    assert clean('<a href="http://exam](ple.com">foo</a>') is None


### PR DESCRIPTION
`bleach==2.1.3` now raises a `ValueError: Invalid IPv6 URL` exception from `urllib` if it tries to parse an invalid URL.

There's also other places where it may raise a `ValueError` while sanitizing, so catch them all and just fail the render instead of bubbling up the exception.