### PR TITLE
Make all renderers take arbitrary kwargs

### DIFF
--- a/readme_renderer/markdown.py
+++ b/readme_renderer/markdown.py
@@ -23,7 +23,7 @@ variants = {
 }
 
 
-def render(raw, variant="CommonMark"):
+def render(raw, variant="CommonMark", **kwargs):
     renderer = variants.get(variant)
 
     if renderer:

--- a/readme_renderer/rst.py
+++ b/readme_renderer/rst.py
@@ -98,7 +98,7 @@ SETTINGS = {
 }
 
 
-def render(raw, stream=None):
+def render(raw, stream=None, **kwargs):
     if stream is None:
         # Use a io.StringIO as the warning stream to prevent warnings from
         # being printed to sys.stderr.

--- a/readme_renderer/txt.py
+++ b/readme_renderer/txt.py
@@ -25,6 +25,6 @@ except ImportError:
 from .clean import clean
 
 
-def render(raw):
+def render(raw, **kwargs):
     rendered = html_escape(raw).replace("\n", "<br>")
     return clean(rendered, tags=["br"])


### PR DESCRIPTION
This makes `readme_renderer`'s renderers easier to use because we can just pass all the parameters from a Content-Type string along regardless of what they are or whether the renderer can use them.