### PR TITLE
Switch to cmarkgfm completely for rendering Markdown

### DIFF
--- a/readme_renderer/markdown.py
+++ b/readme_renderer/markdown.py
@@ -13,25 +13,15 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function
 
-from CommonMark import commonmark
+import cmarkgfm
 
 from .clean import clean
 
 
-try:
-    import cmarkgfm
-except ImportError:
-    cmarkgfm = None
-
-
-variants = {}
-
-if cmarkgfm is not None:
-    variants["gfm"] = cmarkgfm.github_flavored_markdown_to_html
-    # Preferentially use cmarkgfm for CommonMark.
-    variants["CommonMark"] = cmarkgfm.markdown_to_html
-else:
-    variants["CommonMark"] = commonmark
+variants = {
+    "gfm": cmarkgfm.github_flavored_markdown_to_html,
+    "CommonMark": cmarkgfm.markdown_to_html,
+}
 
 
 def render(raw, variant="CommonMark", **kwargs):

--- a/readme_renderer/txt.py
+++ b/readme_renderer/txt.py
@@ -13,14 +13,7 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function
 
-try:
-    from html import escape as html_escape
-except ImportError:
-    from cgi import escape as _html_escape
-
-    def html_escape(s, quote=True):
-        return _html_escape(s, quote=quote)
-
+from html import escape as html_escape
 
 from .clean import clean
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setuptools.setup(
         "bleach>=2.1.0",
         "cmarkgfm>=0.2.0",
         "docutils>=0.13.1",
+        "future",
         "Pygments",
         "six",
     ],

--- a/setup.py
+++ b/setup.py
@@ -60,16 +60,12 @@ setuptools.setup(
     ],
 
     install_requires=[
-        "commonmark>=0.7.4",
         "bleach>=2.1.0",
+        "cmarkgfm>=0.2.0",
         "docutils>=0.13.1",
         "Pygments",
         "six",
     ],
-
-    extras_require={
-        "gfm": "cmarkgfm>=0.1.0"
-    },
 
     entry_points={
         "distutils.commands": [

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -2,7 +2,6 @@ import io
 import glob
 import os
 
-import cmarkgfm
 import pytest
 
 from readme_renderer.markdown import render, variants
@@ -39,7 +38,3 @@ def test_md_fixtures(md_filename, html_filename, variant):
 
 def test_missing_variant():
     assert render('Hello', variant="InvalidVariant") is None
-
-
-def test_cmarkgfm_is_preferred():
-    assert variants['CommonMark'] is cmarkgfm.markdown_to_html

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist = py27,pypy,py34,py35,py36,pep8,py2pep8,packaging
 
 [testenv]
-extras = gfm
 deps =
     pytest
 commands =


### PR DESCRIPTION
Follow up to #67.

Towards https://github.com/pypa/packaging-problems/issues/126

~~Note: There are [wheels](https://github.com/jonparrott/cmarkgfm-wheels) for `cmarkgfm` for basically everything but Python 2.7 on Windows. This is due to the hilariously ancient version of MSVC needed to compile the wheel and `cmark` just outright being uncompilable as-is. Basically, users of 2.7 on Windows will *not* be able to use `readme_renderer` at all. As long as we're okay with that, this can merge.~~

Wheels are available across Windows, Linux, and Mac for 2.7, 3.4, 3.5, and 3.6.