### PR TITLE
Warn about markdown content type when checking RST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include LICENSE README.rst CHANGES.rst
-include tox.ini .coveragerc
+include tox.ini .coveragerc pytest.ini
 
 recursive-include tests *.html
 recursive-include tests *.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    filterwarnings: built-in maker to silence warnings, not recognized by --strict.

--- a/tests/test_integration_distutils.py
+++ b/tests/test_integration_distutils.py
@@ -1,6 +1,8 @@
 import distutils.dist
 
 import mock
+import pytest
+import setuptools.dist
 
 import readme_renderer.integration.distutils
 
@@ -31,6 +33,20 @@ def test_invalid_rst():
     assert 'start-string without end-string' in message_one
     message_two = checker.warn.call_args_list[1][0][0]
     assert 'invalid markup' in message_two
+
+
+@pytest.mark.filterwarnings('ignore:::distutils.dist')
+def test_markdown():
+    dist = setuptools.dist.Distribution(attrs=dict(
+        long_description="Hello, I am some text.",
+        long_description_content_type="text/markdown"))
+    checker = readme_renderer.integration.distutils.Check(dist)
+    checker.warn = mock.Mock()
+
+    checker.check_restructuredtext()
+
+    checker.warn.assert_called()
+    assert 'content type' in checker.warn.call_args[0][0]
 
 
 def test_invalid_missing():


### PR DESCRIPTION
Closes #81 and consequently #63.