### PR TITLE
Allow width, height, alt, and align attributes on img tags.

### DIFF
--- a/readme_renderer/clean.py
+++ b/readme_renderer/clean.py
@@ -42,7 +42,7 @@ ALLOWED_ATTRIBUTES = {
     # Custom Additions
     "*": ["id"],
     "hr": ["class"],
-    "img": ["src"],
+    "img": ["src", "width", "height", "alt", "align"],
     "span": ["class"],
     "th": ["align"],
     "td": ["align"],

--- a/tests/fixtures/test_GFM_img.html
+++ b/tests/fixtures/test_GFM_img.html
@@ -1,0 +1,2 @@
+<p><img alt="Image of Yaktocat" src="https://octodex.github.com/images/yaktocat.png"></p>
+<img alt="Image of Yaktocat" height="100px" src="https://octodex.github.com/images/yaktocat.png" width="20%">

--- a/tests/fixtures/test_GFM_img.md
+++ b/tests/fixtures/test_GFM_img.md
@@ -1,0 +1,3 @@
+![Image of Yaktocat](https://octodex.github.com/images/yaktocat.png)
+
+<img src="https://octodex.github.com/images/yaktocat.png" width="20%" height="100px" alt="Image of Yaktocat">

--- a/tests/fixtures/test_rst_img_attrs.html
+++ b/tests/fixtures/test_rst_img_attrs.html
@@ -1,0 +1,1 @@
+<img align="right" alt="alternate text" height="100px" src="https://example.com/badge.svg" width="25.0%">

--- a/tests/fixtures/test_rst_img_attrs.rst
+++ b/tests/fixtures/test_rst_img_attrs.rst
@@ -1,0 +1,5 @@
+.. image:: https://example.com/badge.svg
+   :height: 100px
+   :width: 25.0%
+   :alt: alternate text
+   :align: right

--- a/tests/fixtures/test_rst_linkify.html
+++ b/tests/fixtures/test_rst_linkify.html
@@ -1,5 +1,5 @@
-<a href="https://travis-ci.org/tulsawebdevs/django-multi-gtfs" rel="nofollow"><img src="https://travis-ci.org/tulsawebdevs/django-multi-gtfs.svg?branch=master"></a>
-<a href="https://coveralls.io/github/tulsawebdevs/django-multi-gtfs" rel="nofollow"><img src="https://coveralls.io/repos/github/tulsawebdevs/django-multi-gtfs/badge.svg?branch=django19"></a>
+<a href="https://travis-ci.org/tulsawebdevs/django-multi-gtfs" rel="nofollow"><img alt="https://travis-ci.org/tulsawebdevs/django-multi-gtfs.svg?branch=master" src="https://travis-ci.org/tulsawebdevs/django-multi-gtfs.svg?branch=master"></a>
+<a href="https://coveralls.io/github/tulsawebdevs/django-multi-gtfs" rel="nofollow"><img alt="https://coveralls.io/repos/github/tulsawebdevs/django-multi-gtfs/badge.svg?branch=django19" src="https://coveralls.io/repos/github/tulsawebdevs/django-multi-gtfs/badge.svg?branch=django19"></a>
 <p><strong>multigtfs</strong> is an <a href="http://choosealicense.com/licenses/apache/" rel="nofollow">Apache 2.0</a>-licensed Django app that supports importing
 and exporting of GTFS feeds.  All features of the <a href="https://developers.google.com/transit/gtfs/reference" rel="nofollow">June 20, 2012 reference</a>
 are supported, including <a href="https://developers.google.com/transit/gtfs/changes#RevisionHistory" rel="nofollow">all changes</a> up to February 17, 2014.


### PR DESCRIPTION
Fixes #44.

Note: warehouse sets `max-width: 100%` for all `img` tags within the project description. This prevents users from being able to completely break the page layout if they set `width` to something ludicrous such as `100000%`. 