### PR TITLE
Add `render_readme` command to render HTML locally.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,33 @@ your Markdown description as Markdown if it has some invalid or incorrect
 syntax.
 
 
+Render Markup Locally
+---------------------
+
+You can render the HTML that will be generated from your ``long_description`` using:
+
+.. code-block:: console
+
+	$ python setup.py render_readme
+
+The rendered HTML will be output to the console by default.
+
+If you would like to send the output to a web browser instead, use the ``--preview`` flag:
+
+.. code-block:: console
+
+	$ python setup.py render_readme --preview
+
+You can also control the Pygments style used in syntax highlighting using the
+``--style`` flag, or eliminate syntax highlighting altogether by using the
+``--no-color`` flag:
+
+.. code-block:: console
+
+	$ python setup.py render_readme --style=monokai # <-- Pygments style name
+	$ python setup.py render_readme --no-color
+
+
 Code of Conduct
 ---------------
 

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ You can render the HTML that will be generated from your ``long_description`` us
 
 .. code-block:: console
 
-	$ python setup.py render_readme
+    $ python setup.py render_readme
 
 The rendered HTML will be output to the console by default.
 
@@ -53,7 +53,7 @@ If you would like to send the output to a web browser instead, use the ``--previ
 
 .. code-block:: console
 
-	$ python setup.py render_readme --preview
+    $ python setup.py render_readme --preview
 
 You can also control the Pygments style used in syntax highlighting using the
 ``--style`` flag, or eliminate syntax highlighting altogether by using the
@@ -61,8 +61,8 @@ You can also control the Pygments style used in syntax highlighting using the
 
 .. code-block:: console
 
-	$ python setup.py render_readme --style=monokai # <-- Pygments style name
-	$ python setup.py render_readme --no-color
+    $ python setup.py render_readme --style=monokai # <-- Pygments style name
+    $ python setup.py render_readme --no-color
 
 
 Code of Conduct

--- a/readme_renderer/integration/distutils.py
+++ b/readme_renderer/integration/distutils.py
@@ -126,7 +126,7 @@ class RenderReadme(Command):
             self.distribution.metadata, 'long_description_content_type', None)
 
         RST_TYPE = 'text/x-rst'
-        MD_TYPE  = 'text/markdown'
+        MD_TYPE = 'text/markdown'
         PLAIN_TYPE = 'text/plain'
 
         if content_type == RST_TYPE:
@@ -136,7 +136,7 @@ class RenderReadme(Command):
             from ..markdown import render as md_render
             return md_render
         elif content_type == PLAIN_TYPE:
-            from ..txt import render as txt_render 
+            from ..txt import render as txt_render
             return txt_render
         else:
             from ..rst import render as rst_render

--- a/readme_renderer/integration/distutils.py
+++ b/readme_renderer/integration/distutils.py
@@ -16,10 +16,18 @@ from __future__ import absolute_import, division, print_function
 import cgi
 import io
 import re
+import sys
+import webbrowser
 
 import distutils.log
 from distutils.command.check import check as _check
+from distutils.core import Command
+from tempfile import NamedTemporaryFile
 import six
+
+from pygments import highlight
+from pygments.formatters import Terminal256Formatter
+from pygments.lexers import HtmlLexer
 
 from ..rst import render
 
@@ -92,3 +100,78 @@ class Check(_check):
         self.announce(
             "The project's long description is valid RST.",
             level=distutils.log.INFO)
+
+
+class RenderReadme(Command):
+
+    """Render and display the long description as HTML."""
+    description = ("render the long description as HTML")
+    user_options = [("preview", None,
+                     "Preview readme"),
+                    ("no-color", None,
+                     "Do not colorize..."),
+                    ("style=", None,
+                     "Pygments style to use to colorize HTML output.")]
+
+    def initialize_options(self):
+        self.preview = False
+        self.no_color = False
+        self.style = 'native'
+
+    def finalize_options(self):
+        pass
+
+    def get_renderer(self):
+        content_type = getattr(
+            self.distribution.metadata, 'long_description_content_type', None)
+
+        RST_TYPE = 'text/x-rst'
+        MD_TYPE  = 'text/markdown'
+        PLAIN_TYPE = 'text/plain'
+
+        if content_type == RST_TYPE:
+            from ..rst import render as rst_render
+            return rst_render
+        elif content_type == MD_TYPE:
+            from ..markdown import render as md_render
+            return md_render
+        elif content_type == PLAIN_TYPE:
+            from ..txt import render as txt_render 
+            return txt_render
+        else:
+            from ..rst import render as rst_render
+            return rst_render
+
+    def run(self):
+        """Runs the command."""
+
+        data = self.distribution.get_long_description()
+        stream = io.StringIO()
+        # TODO: this will only work for RST!!!
+        render = self.get_renderer()
+        markup = render(data, stream=stream)
+
+        for line in stream.getvalue().splitlines():
+            if line.startswith("<string>"):
+                line = line[8:]
+            self.warn(line)
+
+        if markup is None:
+            self.warn("Invalid markup which will not be rendered on PyPI.")
+
+        if self.preview:
+            with NamedTemporaryFile(
+                prefix='render_readme_',
+                suffix='.html',
+                delete=False,
+            ) as f:
+                print('Writing readme to {0}'.format(f.name))
+                f.write(markup.encode('utf-8'))
+
+            webbrowser.open('file://' + f.name.replace('\\', '/'))
+        else:
+            if not self.no_color:
+                lexer = HtmlLexer()
+                formatter = Terminal256Formatter(style=self.style)
+                markup = highlight(markup, lexer, formatter)
+            sys.stdout.write(markup)

--- a/readme_renderer/integration/distutils.py
+++ b/readme_renderer/integration/distutils.py
@@ -42,6 +42,11 @@ _REPORT_RE = re.compile(
     r'(?P<message>.*)', re.DOTALL | re.MULTILINE)
 
 
+RST_TYPE = 'text/x-rst'
+MD_TYPE = 'text/markdown'
+PLAIN_TYPE = 'text/plain'
+
+
 @six.python_2_unicode_compatible
 class _WarningStream(object):
     def __init__(self):
@@ -124,10 +129,6 @@ class RenderReadme(Command):
     def get_renderer(self):
         content_type = getattr(
             self.distribution.metadata, 'long_description_content_type', None)
-
-        RST_TYPE = 'text/x-rst'
-        MD_TYPE = 'text/markdown'
-        PLAIN_TYPE = 'text/plain'
 
         if content_type == RST_TYPE:
             from ..rst import render as rst_render

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setuptools.setup(
     entry_points={
         "distutils.commands": [
             "check = readme_renderer.integration.distutils:Check",
+            "render_readme = readme_renderer.integration.distutils:RenderReadme",
         ],
     },
 

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setuptools.setup(
     entry_points={
         "distutils.commands": [
             "check = readme_renderer.integration.distutils:Check",
-            "render_readme = readme_renderer.integration.distutils:RenderReadme",
+            "render_readme = readme_renderer.integration.distutils:RenderReadme",  # noqa: E501
         ],
     },
 

--- a/tests/test_integration_distutils.py
+++ b/tests/test_integration_distutils.py
@@ -74,3 +74,60 @@ def test_invalid_empty():
 
     checker.warn.assert_called_once_with(mock.ANY)
     assert 'missing' in checker.warn.call_args[0][0]
+
+
+def test_render_readme_default(capfd):
+    long_desc = "This is a simple README."
+    dist = distutils.dist.Distribution(attrs=dict(long_description=long_desc))
+
+    renderer = readme_renderer.integration.distutils.RenderReadme(dist)
+    renderer.no_color = True
+    renderer.run()
+
+    expected = "<p>This is a simple README.</p>\n"
+    assert expected == capfd.readouterr().out
+
+
+@pytest.mark.filterwarnings('ignore:::distutils.dist')
+def test_render_readme_md(capfd):
+    long_desc = "This is a simple README."
+    dist = setuptools.dist.Distribution(attrs=dict(long_description=long_desc,
+                                                   long_description_content_type='text/x-rst'))
+
+    renderer = readme_renderer.integration.distutils.RenderReadme(dist)
+    renderer.warn = mock.Mock()
+    renderer.no_color = True
+    renderer.run()
+
+    expected = "<p>This is a simple README.</p>\n"
+    assert expected == capfd.readouterr().out
+
+
+@pytest.mark.filterwarnings('ignore:::distutils.dist')
+def test_render_readme_md(capfd):
+    long_desc = "This is a simple README."
+    dist = setuptools.dist.Distribution(attrs=dict(long_description=long_desc,
+                                                   long_description_content_type='text/markdown'))
+
+    renderer = readme_renderer.integration.distutils.RenderReadme(dist)
+    renderer.warn = mock.Mock()
+    renderer.no_color = True
+    renderer.run()
+
+    expected = "<p>This is a simple README.</p>\n"
+    assert expected == capfd.readouterr().out
+
+
+@pytest.mark.filterwarnings('ignore:::distutils.dist')
+def test_render_readme_txt(capfd):
+    long_desc = "This is a simple README."
+    dist = setuptools.dist.Distribution(attrs=dict(long_description=long_desc,
+                                                   long_description_content_type='text/plain'))
+
+    renderer = readme_renderer.integration.distutils.RenderReadme(dist)
+    renderer.warn = mock.Mock()
+    renderer.no_color = True
+    renderer.run()
+
+    expected = "This is a simple README."
+    assert expected == capfd.readouterr().out

--- a/tests/test_integration_distutils.py
+++ b/tests/test_integration_distutils.py
@@ -77,8 +77,8 @@ def test_invalid_empty():
 
 
 def test_render_readme_default(capfd):
-    long_desc = "This is a simple README."
-    dist = distutils.dist.Distribution(attrs=dict(long_description=long_desc))
+    dist_opts = {'long_description': "This is a simple README."}
+    dist = distutils.dist.Distribution(attrs=dist_opts)
 
     renderer = readme_renderer.integration.distutils.RenderReadme(dist)
     renderer.no_color = True
@@ -89,10 +89,10 @@ def test_render_readme_default(capfd):
 
 
 @pytest.mark.filterwarnings('ignore:::distutils.dist')
-def test_render_readme_md(capfd):
-    long_desc = "This is a simple README."
-    dist = setuptools.dist.Distribution(attrs=dict(long_description=long_desc,
-                                                   long_description_content_type='text/x-rst'))
+def test_render_readme_rst(capfd):
+    dist_opts = {'long_description': "This is a simple README.",
+                 'long_description_content_type': 'text/x-rst'}
+    dist = setuptools.dist.Distribution(attrs=dist_opts)
 
     renderer = readme_renderer.integration.distutils.RenderReadme(dist)
     renderer.warn = mock.Mock()
@@ -105,9 +105,9 @@ def test_render_readme_md(capfd):
 
 @pytest.mark.filterwarnings('ignore:::distutils.dist')
 def test_render_readme_md(capfd):
-    long_desc = "This is a simple README."
-    dist = setuptools.dist.Distribution(attrs=dict(long_description=long_desc,
-                                                   long_description_content_type='text/markdown'))
+    dist_opts = {'long_description': "This is a simple README.",
+                 'long_description_content_type': 'text/markdown'}
+    dist = setuptools.dist.Distribution(attrs=dist_opts)
 
     renderer = readme_renderer.integration.distutils.RenderReadme(dist)
     renderer.warn = mock.Mock()
@@ -120,9 +120,9 @@ def test_render_readme_md(capfd):
 
 @pytest.mark.filterwarnings('ignore:::distutils.dist')
 def test_render_readme_txt(capfd):
-    long_desc = "This is a simple README."
-    dist = setuptools.dist.Distribution(attrs=dict(long_description=long_desc,
-                                                   long_description_content_type='text/plain'))
+    dist_opts = {'long_description': "This is a simple README.",
+                 'long_description_content_type': 'text/plain'}
+    dist = setuptools.dist.Distribution(attrs=dist_opts)
 
     renderer = readme_renderer.integration.distutils.RenderReadme(dist)
     renderer.warn = mock.Mock()


### PR DESCRIPTION
This allows users to render HTML locally in order to preview the
rendered markup prior to uploading a package.  Optionally, the
user can also control syntax highlighting and send the markup to
a web browser.