### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal=1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
The wheel package format supports including the license file. This is
done using the [metadata] section in the setup.cfg file. For additional
information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file

Helps project comply with its own license:

> 4. Redistribution. You may reproduce and distribute copies of the
>    Work or Derivative Works thereof in any medium, with or without
>    modifications, and in Source or Object form, provided that You
>    meet the following conditions:
>
>    (a) You must give any other recipients of the Work or
>        Derivative Works a copy of this License;