### PR TITLE
Width and alignment of RST images

### DIFF
--- a/readme_renderer/clean.py
+++ b/readme_renderer/clean.py
@@ -42,7 +42,7 @@ ALLOWED_ATTRIBUTES = {
     # Custom Additions
     "*": ["id"],
     "hr": ["class"],
-    "img": ["src", "width", "height", "alt", "align"],
+    "img": ["src", "width", "height", "alt", "align", "class"],
     "span": ["class"],
     "th": ["align"],
     "td": ["align"],

--- a/readme_renderer/clean.py
+++ b/readme_renderer/clean.py
@@ -42,7 +42,7 @@ ALLOWED_ATTRIBUTES = {
     # Custom Additions
     "*": ["id"],
     "hr": ["class"],
-    "img": ["src", "width", "height", "alt", "align", "class"],
+    "img": ["src", "width", "height", "alt", "align", "class", "style"],
     "span": ["class"],
     "th": ["align"],
     "td": ["align"],
@@ -50,7 +50,9 @@ ALLOWED_ATTRIBUTES = {
     "p": ["align"],
 }
 
-ALLOWED_STYLES = []
+ALLOWED_STYLES = [
+    "width", "height",
+]
 
 
 def clean(html, tags=None, attributes=None, styles=None):

--- a/tests/fixtures/test_CommonMark_style.html
+++ b/tests/fixtures/test_CommonMark_style.html
@@ -1,0 +1,1 @@
+<img src="https://example.com/badge.png" style="width: 20px; height: 20px;">

--- a/tests/fixtures/test_CommonMark_style.md
+++ b/tests/fixtures/test_CommonMark_style.md
@@ -1,0 +1,1 @@
+<img src="https://example.com/badge.png" style="width: 20px; height: 20px; color:red;">

--- a/tests/fixtures/test_GFM_style.html
+++ b/tests/fixtures/test_GFM_style.html
@@ -1,0 +1,1 @@
+<img src="https://example.com/badge.png" style="width: 20px; height: 20px;">

--- a/tests/fixtures/test_GFM_style.md
+++ b/tests/fixtures/test_GFM_style.md
@@ -1,0 +1,1 @@
+<img src="https://example.com/badge.png" style="width: 20px; height: 20px; color:red;">

--- a/tests/fixtures/test_rst_png_attrs.html
+++ b/tests/fixtures/test_rst_png_attrs.html
@@ -1,1 +1,1 @@
-<img alt="alternate text" src="https://example.com/badge.png">
+<img alt="alternate text" class="align-right" src="https://example.com/badge.png">

--- a/tests/fixtures/test_rst_png_attrs.html
+++ b/tests/fixtures/test_rst_png_attrs.html
@@ -1,1 +1,1 @@
-<img alt="alternate text" class="align-right" src="https://example.com/badge.png">
+<img alt="alternate text" class="align-right" src="https://example.com/badge.png" style="width: 25.0%; height: 100px;">

--- a/tests/fixtures/test_rst_svg_attrs.html
+++ b/tests/fixtures/test_rst_svg_attrs.html
@@ -1,1 +1,1 @@
-<img alt="alternate text" class="align-right" src="https://example.com/badge.svg">
+<img alt="alternate text" class="align-right" src="https://example.com/badge.svg" style="width: 25.0%; height: 100px;">

--- a/tests/fixtures/test_rst_svg_attrs.html
+++ b/tests/fixtures/test_rst_svg_attrs.html
@@ -1,1 +1,1 @@
-<img alt="alternate text" src="https://example.com/badge.svg">
+<img alt="alternate text" class="align-right" src="https://example.com/badge.svg">


### PR DESCRIPTION
RST renders images with `class="align-..." style="width: ...; height: ..."`.  This pull request stops bleach from removing image styling. 

Allowing `class` and `style` attributes can be controversial, but this PR does not introduce anything new - `width` and `height` attributes are already allowed (and other styles won't be allowed), and `class` can be already assigned to `span` and other elements.

This should follows PR https://github.com/pypa/readme_renderer/pull/113 (merge it first for a smaller diff) and fixes issue https://github.com/pypa/readme_renderer/issues/112.  
Overall goal is to fix https://github.com/pypa/warehouse/issues/4023. 