### PR TITLE
Recommend using `twine check` instead

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,30 +12,8 @@ reStructuredText (``.rst``), and plain text.
 Check Description Locally
 -------------------------
 
-reStructuredText
-~~~~~~~~~~~~~~~~
-
-To locally check whether your reStructuredText long descriptions will render on
-PyPI, simply install the ``readme_renderer`` library using:
-
-.. code-block:: console
-
-    $ pip install readme_renderer
-    $ python setup.py check -r -s
-    running check
-
-If there's a problem rendering your ``long_description``, the check
-will tell you. If your ``long_description`` is fine, you'll get no
-output.
-
-
-Markdown
-~~~~~~~~
-
-Checking your Markdown long descriptions is unecessary, because unlike rST,
-where a properly rendered description is all-or-nothing, PyPI will still render
-your Markdown description as Markdown if it has some invalid or incorrect
-syntax.
+To locally check whether your long descriptions will render on PyPI, first
+build your distributions, and then use the |twine check|_ command.
 
 
 Code of Conduct
@@ -44,4 +22,7 @@ Code of Conduct
 Everyone interacting in the readme_renderer project's codebases, issue trackers,
 chat rooms, and mailing lists is expected to follow the `PyPA Code of Conduct`_.
 
+
+.. |twine check| replace:: ``twine check``
+.. _twine check: https://github.com/pypa/twine#twine-check
 .. _PyPA Code of Conduct: https://www.pypa.io/en/latest/code-of-conduct/

--- a/README.rst
+++ b/README.rst
@@ -24,5 +24,5 @@ chat rooms, and mailing lists is expected to follow the `PyPA Code of Conduct`_.
 
 
 .. |twine check| replace:: ``twine check``
-.. _twine check: https://github.com/pypa/twine#twine-check
+.. _twine check: https://packaging.python.org/guides/making-a-pypi-friendly-readme#validating-restructuredtext-markup
 .. _PyPA Code of Conduct: https://www.pypa.io/en/latest/code-of-conduct/

--- a/readme_renderer/integration/distutils.py
+++ b/readme_renderer/integration/distutils.py
@@ -67,7 +67,8 @@ class Check(_check):
         Command.warn(
             self,
             "This command has been deprecated. Use `twine check` instead: "
-            "https://github.com/pypa/twine#twine-check"
+            "https://packaging.python.org/guides/making-a-pypi-friendly-readme"
+            "#validating-restructuredtext-markup"
         )
 
         data = self.distribution.get_long_description()

--- a/readme_renderer/integration/distutils.py
+++ b/readme_renderer/integration/distutils.py
@@ -19,6 +19,7 @@ import re
 
 import distutils.log
 from distutils.command.check import check as _check
+from distutils.core import Command
 import six
 
 from ..rst import render
@@ -61,6 +62,14 @@ class Check(_check):
         """
         Checks if the long string fields are reST-compliant.
         """
+        # Warn that this command is deprecated
+        # Don't use self.warn() because it will cause the check to fail.
+        Command.warn(
+            self,
+            "This command has been deprecated. Use `twine check` instead: "
+            "https://github.com/pypa/twine#twine-check"
+        )
+
         data = self.distribution.get_long_description()
         content_type = getattr(
             self.distribution.metadata, 'long_description_content_type', None)


### PR DESCRIPTION
This PR updates the README for this repo to recommend using the new `twine check` command instead of `setup.py check -r -s`.

It also adds a deprecation notice for the old command.

This should be merged once the new version of Twine is released.