### PR TITLE
Add command-line entrypoint

### DIFF
--- a/readme_renderer/__main__.py
+++ b/readme_renderer/__main__.py
@@ -8,16 +8,13 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description="Renders a .rst README to HTML",
     )
-    parser.add_argument('input', help="Input README file")
-    parser.add_argument('-o', '--output', help="Output file (default: stdout)")
+    parser.add_argument('input', help="Input README file",
+                        type=argparse.FileType('r'))
+    parser.add_argument('-o', '--output', help="Output file (default: stdout)",
+                        type=argparse.FileType('w'), default='-')
     args = parser.parse_args()
-    if args.output:
-        output_file = open(args.output, 'w')
-    else:
-        output_file = sys.stdout
-    input_file = open(args.input)
 
-    rendered = render(input_file.read(), stream=sys.stderr)
+    rendered = render(args.input.read(), stream=sys.stderr)
     if rendered is None:
         sys.exit(1)
-    print(rendered, file=output_file)
+    print(rendered, file=args.output)

--- a/readme_renderer/__main__.py
+++ b/readme_renderer/__main__.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import, print_function
+from readme_renderer.rst import render
+import sys
+
+
+if len(sys.argv) == 2:
+    with open(sys.argv[1]) as fp:
+        out = render(fp.read(), stream=sys.stderr)
+        if out is not None:
+            print(out)
+        else:
+            sys.exit(1)
+else:
+    print("Syntax: python -m readme_renderer <file.rst>", file=sys.stderr)

--- a/readme_renderer/__main__.py
+++ b/readme_renderer/__main__.py
@@ -1,14 +1,23 @@
 from __future__ import absolute_import, print_function
+import argparse
 from readme_renderer.rst import render
 import sys
 
 
-if len(sys.argv) == 2:
-    with open(sys.argv[1]) as fp:
-        out = render(fp.read(), stream=sys.stderr)
-        if out is not None:
-            print(out)
-        else:
-            sys.exit(1)
-else:
-    print("Syntax: python -m readme_renderer <file.rst>", file=sys.stderr)
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Renders a .rst README to HTML",
+    )
+    parser.add_argument('input', help="Input README file")
+    parser.add_argument('-o', '--output', help="Output file (default: stdout)")
+    args = parser.parse_args()
+    if args.output:
+        output_file = open(args.output, 'w')
+    else:
+        output_file = sys.stdout
+    input_file = open(args.input)
+
+    rendered = render(input_file.read(), stream=sys.stderr)
+    if rendered is None:
+        sys.exit(1)
+    print(rendered, file=output_file)


### PR DESCRIPTION
Allows you to run `python -m readme_renderer`

Closes #52, closes #53, closes #101.