### PR TITLE
Fix typo in the warning to install readme_renderer[md]

### DIFF
--- a/readme_renderer/markdown.py
+++ b/readme_renderer/markdown.py
@@ -25,7 +25,7 @@ from .clean import clean
 
 _EXTRA_WARNING = (
     "Markdown renderers are not available. "
-    "Install 'readme_render[md]' to enable Markdown rendering."
+    "Install 'readme_renderer[md]' to enable Markdown rendering."
 )
 
 try:

--- a/tests/test_noextra.py
+++ b/tests/test_noextra.py
@@ -11,5 +11,5 @@ def test_no_extra(variant):
     assert len(warnings) == 1
     assert warnings[0].message.args[0] == (
         "Markdown renderers are not available. "
-        "Install 'readme_render[md]' to enable Markdown rendering."
+        "Install 'readme_renderer[md]' to enable Markdown rendering."
     )


### PR DESCRIPTION
Doing "pip install readme_render[md]" (without 'er' after 'render') fails.

I noticed this when doing 'twine check' on a package with a README in MarkDown format.