### PR TITLE
Fix regression for image height/width

### DIFF
--- a/readme_renderer/rst.py
+++ b/readme_renderer/rst.py
@@ -27,6 +27,18 @@ class ReadMeHTMLTranslator(HTMLTranslator):
     # Overrides base class not to output `<object>` tag for SVG images.
     object_image_types = {}
 
+    def emptytag(self, node, tagname, suffix="\n", **attributes):
+        """Override this to add back the width/height attributes."""
+        if tagname == "img":
+            if "width" in node:
+                attributes["width"] = node["width"]
+            if "height" in node:
+                attributes["height"] = node["height"]
+
+        return super(ReadMeHTMLTranslator, self).emptytag(
+            node, tagname, suffix, **attributes
+        )
+
 
 SETTINGS = {
     # Cloaking email addresses provides a small amount of additional

--- a/tests/fixtures/test_rst_png_attrs.html
+++ b/tests/fixtures/test_rst_png_attrs.html
@@ -1,1 +1,1 @@
-<img alt="alternate text" class="align-right" src="https://example.com/badge.png">
+<img alt="alternate text" class="align-right" height="100px" src="https://example.com/badge.png" width="25.0%">

--- a/tests/fixtures/test_rst_svg_attrs.html
+++ b/tests/fixtures/test_rst_svg_attrs.html
@@ -1,1 +1,1 @@
-<img alt="alternate text" class="align-right" src="https://example.com/badge.svg">
+<img alt="alternate text" class="align-right" height="100px" src="https://example.com/badge.svg" width="25.0%">


### PR DESCRIPTION
This fixes a regression introduced in #113 where height/width attributes were removed from images defined in reStructuredText.

More discussion here: https://github.com/pypa/readme_renderer/pull/113#discussion_r206366539