### PR TITLE
Remove py2-specific dependencies and fix tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python_version }}
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run tests

--- a/readme_renderer/integration/distutils.py
+++ b/readme_renderer/integration/distutils.py
@@ -20,7 +20,6 @@ import re
 import distutils.log
 from distutils.command.check import check as _check
 from distutils.core import Command
-import six
 
 from ..rst import render
 
@@ -35,7 +34,6 @@ _REPORT_RE = re.compile(
     r'(?P<message>.*)', re.DOTALL | re.MULTILINE)
 
 
-@six.python_2_unicode_compatible
 class _WarningStream(object):
     def __init__(self):
         self.output = io.StringIO()

--- a/readme_renderer/markdown.py
+++ b/readme_renderer/markdown.py
@@ -16,16 +16,11 @@ from __future__ import absolute_import, division, print_function
 import re
 import warnings
 
+from html.parser import unescape
+
 import pygments
 import pygments.lexers
 import pygments.formatters
-
-try:
-    from six.moves.html_parser import unescape
-except ImportError:  # Python 2
-    from six.moves import html_parser
-
-    unescape = html_parser.HTMLParser().unescape
 
 from .clean import clean
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setuptools.setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    install_requires=["bleach>=2.1.0", "docutils>=0.13.1", "Pygments>=2.5.1", "six"],
+    install_requires=["bleach>=2.1.0", "docutils>=0.13.1", "Pygments>=2.5.1"],
     entry_points={
         "distutils.commands": ["check = readme_renderer.integration.distutils:Check"],
     },

--- a/tests/test_integration_distutils.py
+++ b/tests/test_integration_distutils.py
@@ -1,6 +1,6 @@
 import distutils.dist
+import unittest.mock
 
-import mock
 import pytest
 import setuptools.dist
 
@@ -11,7 +11,7 @@ def test_valid_rst():
     dist = distutils.dist.Distribution(attrs=dict(
         long_description="Hello, I am some text."))
     checker = readme_renderer.integration.distutils.Check(dist)
-    checker.warn = mock.Mock()
+    checker.warn = unittest.mock.Mock()
 
     checker.check_restructuredtext()
 
@@ -22,14 +22,14 @@ def test_invalid_rst():
     dist = distutils.dist.Distribution(attrs=dict(
         long_description="Hello, I am some `totally borked< text."))
     checker = readme_renderer.integration.distutils.Check(dist)
-    checker.warn = mock.Mock()
-    checker.announce = mock.Mock()
+    checker.warn = unittest.mock.Mock()
+    checker.announce = unittest.mock.Mock()
 
     checker.check_restructuredtext()
 
     # Should warn once for the syntax error, and finally to warn that the
     # overall syntax is invalid
-    checker.warn.assert_called_once_with(mock.ANY)
+    checker.warn.assert_called_once_with(unittest.mock.ANY)
     message = checker.warn.call_args[0][0]
     assert 'invalid markup' in message
     assert 'line 1: Warning:' in message
@@ -47,14 +47,14 @@ def test_malicious_rst():
     dist = distutils.dist.Distribution(attrs=dict(
         long_description=description))
     checker = readme_renderer.integration.distutils.Check(dist)
-    checker.warn = mock.Mock()
-    checker.announce = mock.Mock()
+    checker.warn = unittest.mock.Mock()
+    checker.announce = unittest.mock.Mock()
 
     checker.check_restructuredtext()
 
     # Should warn once for the syntax error, and finally to warn that the
     # overall syntax is invalid
-    checker.warn.assert_called_once_with(mock.ANY)
+    checker.warn.assert_called_once_with(unittest.mock.ANY)
     message = checker.warn.call_args[0][0]
     assert 'directive disabled' in message
 
@@ -68,7 +68,7 @@ def test_markdown():
         long_description="Hello, I am some text.",
         long_description_content_type="text/markdown"))
     checker = readme_renderer.integration.distutils.Check(dist)
-    checker.warn = mock.Mock()
+    checker.warn = unittest.mock.Mock()
 
     checker.check_restructuredtext()
 
@@ -79,11 +79,11 @@ def test_markdown():
 def test_invalid_missing():
     dist = distutils.dist.Distribution(attrs=dict())
     checker = readme_renderer.integration.distutils.Check(dist)
-    checker.warn = mock.Mock()
+    checker.warn = unittest.mock.Mock()
 
     checker.check_restructuredtext()
 
-    checker.warn.assert_called_once_with(mock.ANY)
+    checker.warn.assert_called_once_with(unittest.mock.ANY)
     assert 'missing' in checker.warn.call_args[0][0]
 
 
@@ -91,9 +91,9 @@ def test_invalid_empty():
     dist = distutils.dist.Distribution(attrs=dict(
         long_description=""))
     checker = readme_renderer.integration.distutils.Check(dist)
-    checker.warn = mock.Mock()
+    checker.warn = unittest.mock.Mock()
 
     checker.check_restructuredtext()
 
-    checker.warn.assert_called_once_with(mock.ANY)
+    checker.warn.assert_called_once_with(unittest.mock.ANY)
     assert 'missing' in checker.warn.call_args[0][0]

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -3,7 +3,6 @@ import glob
 import os.path
 
 import pytest
-import six
 
 from readme_renderer.rst import render
 
@@ -46,7 +45,7 @@ def test_rst_002():
 
 
 def test_rst_raw():
-    warnings = six.StringIO()
+    warnings = io.StringIO()
     assert render("""
 .. raw:: html
     <script>I am evil</script>

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist = py36,py37,py38,py39,pep8,packaging,noextra
 [testenv]
 deps =
     pytest
-    mock
 commands =
     py.test --strict {posargs}
 extras = md

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py36,py37,py38,py39,pep8,packaging,noextra
 deps =
     pytest
 commands =
-    py.test --strict {posargs}
+    pytest --strict {posargs}
 extras = md
 
 [testenv:pep8]


### PR DESCRIPTION
1. Fix GitHub actions to actually test against the requested Python version (rather than 2.7 everywhere).
2. Replace external `mock` with py3's `unittest.mock`.
3. Remove dependency on `six`.
4. Use the new `pytest` executable name.