### PR TITLE
Remove unnecessary `__future__` imports.

### DIFF
--- a/readme_renderer/__about__.py
+++ b/readme_renderer/__about__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import, division, print_function
 
 __all__ = [
     "__title__", "__summary__", "__uri__", "__version__", "__author__",

--- a/readme_renderer/__init__.py
+++ b/readme_renderer/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import, division, print_function

--- a/readme_renderer/__main__.py
+++ b/readme_renderer/__main__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 import argparse
 from readme_renderer.rst import render
 import sys

--- a/readme_renderer/clean.py
+++ b/readme_renderer/clean.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import, division, print_function
 
 import functools
 

--- a/readme_renderer/integration/__init__.py
+++ b/readme_renderer/integration/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import, division, print_function

--- a/readme_renderer/integration/distutils.py
+++ b/readme_renderer/integration/distutils.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import, division, print_function
 
 import cgi
 import io

--- a/readme_renderer/markdown.py
+++ b/readme_renderer/markdown.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import, division, print_function
 
 import re
 import warnings

--- a/readme_renderer/rst.py
+++ b/readme_renderer/rst.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import, division, print_function
 
 import io
 

--- a/readme_renderer/txt.py
+++ b/readme_renderer/txt.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import, division, print_function
 
 import sys
 


### PR DESCRIPTION
Now that `readme_renderer` is Python 3 only these can be removed as they all became the default in 3.0