### PR TITLE
Relax cmarkgfm version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,6 @@ setuptools.setup(
     entry_points={
         "distutils.commands": ["check = readme_renderer.integration.distutils:Check"],
     },
-    extras_require={"md": "cmarkgfm>=0.5.0,<0.6.0"},
+    extras_require={"md": "cmarkgfm>=0.5.0"},
     packages=setuptools.find_packages(exclude=["tests", "tests.*"]),
 )


### PR DESCRIPTION
As confirmed in https://github.com/pypa/readme_renderer/pull/202#issuecomment-887603892, cmarkgfm 0.6.0 is compatible with readme_renderer.  IMHO the minor version shouldn't be pinned so this PR is dropping the upper limit.