### PR TITLE
tox: change pep8/noextra environments to use Python 3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ commands =
 extras = md
 
 [testenv:pep8]
-basepython = python3.6
+basepython = python3
 deps =
     flake8
     pep8-naming
@@ -26,7 +26,7 @@ commands =
     python -m twine check dist/*
 
 [testenv:noextra]
-basepython = python3.6
+basepython = python3
 extras =
 
 [flake8]


### PR DESCRIPTION
Instead of hard-coded 3.6. This fix the CI lint job.