### PR TITLE
Allow `start` attribute in ordered lists

### DIFF
--- a/readme_renderer/clean.py
+++ b/readme_renderer/clean.py
@@ -55,6 +55,7 @@ ALLOWED_ATTRIBUTES = {
     "h6": ["align"],
     "code": ["class"],
     "p": ["align"],
+    "ol": ["start"],
 }
 
 ALLOWED_STYLES = [

--- a/tests/fixtures/test_GFM_025.html
+++ b/tests/fixtures/test_GFM_025.html
@@ -1,0 +1,12 @@
+<ol start="3">
+<li>Foo</li>
+</ol>
+<p>Some text</p>
+<ol start="2">
+<li>
+<p>Bar</p>
+</li>
+<li>
+<p>Baz</p>
+</li>
+</ol>

--- a/tests/fixtures/test_GFM_025.md
+++ b/tests/fixtures/test_GFM_025.md
@@ -1,0 +1,7 @@
+3. Foo
+
+Some text
+
+2. Bar
+
+1. Baz


### PR DESCRIPTION
Ordered lists [can take a `start` attribute](https://www.w3schools.com/Tags/att_ol_start.asp) which specify the value of the first item in the list.

Fixes #207