### PR TITLE
No limit rendering RST one column field names

### DIFF
--- a/readme_renderer/rst.py
+++ b/readme_renderer/rst.py
@@ -88,6 +88,10 @@ SETTINGS = {
     # Use the short form of syntax highlighting so that the generated
     # Pygments CSS can be used to style the output.
     "syntax_highlight": "short",
+
+    # Maximum width (in characters) for one-column field names.
+    # 0 means "no limit"
+    "field_name_limit": 0,
 }
 
 


### PR DESCRIPTION
Fixes #155

See [`field_name_limit`](https://docutils.sourceforge.io/docs/user/config.html#field-name-limit) in docutils documentation. It could be also set to a greater value than the default (`14`), but seems to me that no limit is preferred.