### PR TITLE
Add `py.typed` to the built wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setuptools.setup(
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     install_requires=["bleach>=2.1.0", "docutils>=0.13.1", "Pygments>=2.5.1"],
+    include_package_data=True,
     entry_points={
         "distutils.commands": ["check = readme_renderer.integration.distutils:Check"],
     },


### PR DESCRIPTION
Fixes #227 by including all data files specified in MANIFEST.in; see: https://setuptools.pypa.io/en/latest/userguide/datafiles.html.

Confirmed that installing the wheel in a Twine venv resolves the mypy errors.