### PR TITLE
Fix renderer ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,11 @@ build-backend = "setuptools.build_meta:__legacy__"
 [tool.mypy]
 strict = true
 warn_unused_configs = true
+show_error_codes = true
+enable_error_code = [
+    "ignore-without-code"
+]
+
 [[tool.mypy.overrides]]
 # These modules do not yet have types available.
 module = [

--- a/readme_renderer/markdown.py
+++ b/readme_renderer/markdown.py
@@ -67,7 +67,7 @@ def render(
         return None
 
     # The renderer is a lambda function, and mypy fails lambdas right now.
-    rendered = renderer(raw)  # type: ignore
+    rendered = renderer(raw)  # type: ignore[no-untyped-call]
 
     if not rendered:
         return None

--- a/readme_renderer/markdown.py
+++ b/readme_renderer/markdown.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import, division, print_function
 
 import re
 import warnings
-from typing import Any, Match, Optional
+from typing import Any, Dict, Callable, Match, Optional
 
 from html import unescape
 
@@ -33,7 +33,7 @@ _EXTRA_WARNING = (
 try:
     import cmarkgfm
     from cmarkgfm.cmark import Options as cmarkgfmOptions
-    variants = {
+    variants: Dict[str, Callable[[str], Any]] = {
         "GFM": lambda raw: cmarkgfm.github_flavored_markdown_to_html(
             raw, options=cmarkgfmOptions.CMARK_OPT_UNSAFE
         ),
@@ -66,8 +66,7 @@ def render(
     if not renderer:
         return None
 
-    # The renderer is a lambda function, and mypy fails lambdas right now.
-    rendered = renderer(raw)  # type: ignore[no-untyped-call]
+    rendered = renderer(raw)
 
     if not rendered:
         return None

--- a/readme_renderer/markdown.py
+++ b/readme_renderer/markdown.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import, division, print_function
 
 import re
 import warnings
-from typing import Any, Dict, Callable, Match, Optional
+from typing import cast, Any, Dict, Callable, Match, Optional
 
 from html import unescape
 
@@ -33,13 +33,13 @@ _EXTRA_WARNING = (
 try:
     import cmarkgfm
     from cmarkgfm.cmark import Options as cmarkgfmOptions
-    variants: Dict[str, Callable[[str], Any]] = {
-        "GFM": lambda raw: cmarkgfm.github_flavored_markdown_to_html(
+    variants: Dict[str, Callable[[str], str]] = {
+        "GFM": lambda raw: cast(str, cmarkgfm.github_flavored_markdown_to_html(
             raw, options=cmarkgfmOptions.CMARK_OPT_UNSAFE
-        ),
-        "CommonMark": lambda raw: cmarkgfm.markdown_to_html(
+        )),
+        "CommonMark": lambda raw: cast(str, cmarkgfm.markdown_to_html(
             raw, options=cmarkgfmOptions.CMARK_OPT_UNSAFE
-        ),
+        )),
     }
 except ImportError:
     warnings.warn(_EXTRA_WARNING)


### PR DESCRIPTION
Follow-up to #225.

Based on: https://mypy.readthedocs.io/en/stable/kinds_of_types.html#callable-types-and-lambdas

mypy can infer lambda types; it seems we just need to annotate the lookup dict.

The `cast` isn't necessary to pass mypy, but offers a little more clarity.

FYI @miketheman 