### PR TITLE
test: update html attribute order

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setuptools.setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    install_requires=["bleach>=2.1.0,<5.0", "docutils>=0.13.1", "Pygments>=2.5.1"],
+    install_requires=["bleach>=2.1.0", "docutils>=0.13.1", "Pygments>=2.5.1"],
     include_package_data=True,
     extras_require={"md": "cmarkgfm>=0.8.0"},
     packages=setuptools.find_packages(exclude=["tests", "tests.*"]),

--- a/tests/fixtures/test_GFM_024.html
+++ b/tests/fixtures/test_GFM_024.html
@@ -1,6 +1,6 @@
 <ul>
-<li><input disabled type="checkbox"> Valid unchecked checkbox</li>
-<li><input checked disabled type="checkbox"> Valid checked checkbox</li>
+<li><input type="checkbox" disabled> Valid unchecked checkbox</li>
+<li><input type="checkbox" checked disabled> Valid checked checkbox</li>
 <li> Invalid enabled checkbox</li>
 <li>
 

--- a/tests/fixtures/test_GFM_img.html
+++ b/tests/fixtures/test_GFM_img.html
@@ -1,4 +1,4 @@
-<p><img alt="Image of Yaktocat" src="https://octodex.github.com/images/yaktocat.png"></p>
+<p><img src="https://octodex.github.com/images/yaktocat.png" alt="Image of Yaktocat"></p>
 <p align="center">
-    <img alt="Image of Yaktocat" height="100px" src="https://octodex.github.com/images/yaktocat.png" width="20%">
+    <img src="https://octodex.github.com/images/yaktocat.png" width="20%" height="100px" alt="Image of Yaktocat">
 </p>


### PR DESCRIPTION
With bleach 5.0.0, attribute order has changed to be preserved from the
origin, rather than alphabetized for consistency.

These tests failed due to the output change.

Closes: #234

Signed-off-by: Mike Fiedler <miketheman@gmail.com>