### PR TITLE
chore: drop support for python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["pypy3", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy-3.7", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setuptools.setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    install_requires=["bleach>=2.1.0", "docutils>=0.13.1", "Pygments>=2.5.1"],
+    install_requires=["bleach>=2.1.0,<5.0", "docutils>=0.13.1", "Pygments>=2.5.1"],
     include_package_data=True,
     extras_require={"md": "cmarkgfm>=0.8.0"},
     packages=setuptools.find_packages(exclude=["tests", "tests.*"]),

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setuptools.setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -60,5 +59,5 @@ setuptools.setup(
     include_package_data=True,
     extras_require={"md": "cmarkgfm>=0.8.0"},
     packages=setuptools.find_packages(exclude=["tests", "tests.*"]),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,pep8,packaging,noextra,mypy
+envlist = py37,py38,py39,py310,pep8,packaging,noextra,mypy
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
It's been EOL since 23 Dec 2021 and is now no longer passing tests.

If someone does still use this library with python 3.6, they will need
to pin the `bleach` dependency to 4.1.0 and `readme_renderer` 34.0

Signed-off-by: Mike Fiedler <miketheman@gmail.com>