### PR TITLE
docs: add badges to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,12 @@
 Readme Renderer
 ===============
 
+.. image:: https://badge.fury.io/py/readme-renderer.svg
+    :target: https://badge.fury.io/py/readme-renderer
+
+.. image:: https://github.com/pypa/readme_renderer/actions/workflows/ci.yml/badge.svg
+    :target: https://github.com/pypa/readme_renderer/actions/workflows/ci.yml
+
 Readme Renderer is a library that will safely render arbitrary
 ``README`` files into HTML. It is designed to be used in Warehouse_ to
 render the ``long_description`` for packages. It can handle Markdown,


### PR DESCRIPTION
Closes #42

We've since changed CI providers to GitHub Actions.

Example rendering:

<img width="316" alt="Screen Shot 2022-07-01 at 7 53 54 PM" src="https://user-images.githubusercontent.com/529516/176978449-7c20e043-937c-4a28-a776-fd240b21d8c5.png">
