### PR TITLE
chore: update codebase for modern python

### DIFF
--- a/readme_renderer/__about__.py
+++ b/readme_renderer/__about__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import, division, print_function
 
 __all__ = [
     "__title__",

--- a/readme_renderer/__init__.py
+++ b/readme_renderer/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import, division, print_function

--- a/readme_renderer/__main__.py
+++ b/readme_renderer/__main__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 import argparse
 from readme_renderer.rst import render
 import sys

--- a/readme_renderer/clean.py
+++ b/readme_renderer/clean.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import, division, print_function
 
 import functools
 from typing import Any, Dict, Iterator, List, Optional

--- a/readme_renderer/markdown.py
+++ b/readme_renderer/markdown.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import, division, print_function
 
 import re
 import warnings
@@ -117,7 +116,7 @@ def _highlight(html: str) -> str:
 
         highlighted = pygments.highlight(code, lexer, formatter)
 
-        return '<pre>{}</pre>'.format(highlighted)
+        return f'<pre>{highlighted}</pre>'
 
     result = code_expr.sub(replacer, html)
 

--- a/readme_renderer/rst.py
+++ b/readme_renderer/rst.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import, division, print_function
 
 import io
 from typing import Any, Dict, IO, Optional, Union
@@ -43,7 +42,7 @@ class ReadMeHTMLTranslator(HTMLTranslator):  # type: ignore[misc] # docutils is 
             if "height" in node:
                 attributes["height"] = node["height"]
 
-        return super(ReadMeHTMLTranslator, self).emptytag(
+        return super().emptytag(
             node, tagname, suffix, **attributes
         )
 

--- a/readme_renderer/txt.py
+++ b/readme_renderer/txt.py
@@ -11,20 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import, division, print_function
 
-import sys
 from typing import Any, Optional
 
 from .clean import clean
 
-if sys.version_info >= (3,):
-    from html import escape as html_escape
-else:
-    from cgi import escape
-
-    def html_escape(s):
-        return escape(s, quote=True).replace("'", '&#x27;')
+from html import escape as html_escape
 
 
 def render(raw: str, **kwargs: Any) -> Optional[str]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-license_file = LICENSE
+license_files = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import, division, print_function
 
 import os
 

--- a/setup.py
+++ b/setup.py
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+import pathlib
 
 import setuptools
 
-base_dir = os.path.dirname(__file__)
+base_dir = pathlib.Path(__file__).parent
 
-with open(os.path.join(base_dir, "readme_renderer", "__about__.py")) as f:
+with open(base_dir.joinpath("readme_renderer", "__about__.py")) as f:
     about = {}
     exec(f.read(), about)
 
-with open(os.path.join(base_dir, "README.rst")) as f:
+with open(base_dir.joinpath("README.rst")) as f:
     long_description = f.read()
 
 

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,27 +1,17 @@
-import glob
-import os
+from pathlib import Path
 
 import pytest
 
 from readme_renderer.markdown import render, variants
 
 
-MD_FIXTURES = [
-    (fn, os.path.splitext(fn)[0] + ".html", variant)
-    for variant in variants
-    for fn in glob.iglob(
-        os.path.join(
-            os.path.dirname(__file__),
-            "fixtures",
-            "test_" + variant + "*.md"
-        )
-    )
-]
-
-
 @pytest.mark.parametrize(
     ("md_filename", "html_filename", "variant"),
-    MD_FIXTURES,
+    [
+        (pytest.param(fn, fn.with_suffix(".html"), variant, id=fn.name))
+        for variant in variants
+        for fn in Path(__file__).parent.glob(f"fixtures/test_{variant}*.md")
+    ],
 )
 def test_md_fixtures(md_filename, html_filename, variant):
     # Get our Markup

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,4 +1,3 @@
-import io
 import glob
 import os
 
@@ -26,11 +25,11 @@ MD_FIXTURES = [
 )
 def test_md_fixtures(md_filename, html_filename, variant):
     # Get our Markup
-    with io.open(md_filename, encoding='utf-8') as f:
+    with open(md_filename, encoding='utf-8') as f:
         md_markup = f.read()
 
     # Get our expected
-    with io.open(html_filename, encoding="utf-8") as f:
+    with open(html_filename, encoding="utf-8") as f:
         expected = f.read()
 
     assert render(md_markup, variant=variant) == expected

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -1,6 +1,5 @@
 import io
-import glob
-import os.path
+from pathlib import Path
 
 import pytest
 
@@ -10,10 +9,8 @@ from readme_renderer.rst import render
 @pytest.mark.parametrize(
     ("rst_filename", "html_filename"),
     [
-        (fn, os.path.splitext(fn)[0] + ".html")
-        for fn in glob.glob(
-            os.path.join(os.path.dirname(__file__), "fixtures", "test_*.rst")
-        )
+        (pytest.param(fn, fn.with_suffix(".html"), id=fn.name))
+        for fn in Path(__file__).parent.glob("fixtures/test_*.rst")
     ],
 )
 def test_rst_fixtures(rst_filename, html_filename):

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -18,11 +18,11 @@ from readme_renderer.rst import render
 )
 def test_rst_fixtures(rst_filename, html_filename):
     # Get our Markup
-    with io.open(rst_filename, encoding='utf-8') as f:
+    with open(rst_filename, encoding='utf-8') as f:
         rst_markup = f.read()
 
     # Get our expected
-    with io.open(html_filename, encoding="utf-8") as f:
+    with open(html_filename, encoding="utf-8") as f:
         expected = f.read()
 
     out = render(rst_markup)

--- a/tests/test_txt.py
+++ b/tests/test_txt.py
@@ -1,4 +1,3 @@
-import io
 import glob
 import os.path
 
@@ -18,11 +17,11 @@ from readme_renderer.txt import render
 )
 def test_txt_fixtures(txt_filename, html_filename):
     # Get our Markup
-    with io.open(txt_filename, encoding='utf-8') as f:
+    with open(txt_filename, encoding='utf-8') as f:
         txt_markup = f.read()
 
     # Get our expected
-    with io.open(html_filename, encoding="utf-8") as f:
+    with open(html_filename, encoding="utf-8") as f:
         expected = f.read()
 
     out = render(txt_markup)

--- a/tests/test_txt.py
+++ b/tests/test_txt.py
@@ -1,5 +1,4 @@
-import glob
-import os.path
+from pathlib import Path
 
 import pytest
 
@@ -9,10 +8,8 @@ from readme_renderer.txt import render
 @pytest.mark.parametrize(
     ("txt_filename", "html_filename"),
     [
-        (fn, os.path.splitext(fn)[0] + ".html")
-        for fn in glob.glob(
-            os.path.join(os.path.dirname(__file__), "fixtures", "test_*.txt")
-        )
+        (pytest.param(fn, fn.with_suffix(".html"), id=fn.name))
+        for fn in Path(__file__).parent.glob("fixtures/test_*.txt")
     ],
 )
 def test_txt_fixtures(txt_filename, html_filename):


### PR DESCRIPTION
We're on Python 3.7 and higher, so we can clean up any artifacts left
from previously-supported Python eras.

Most of the heavy lifting was done with `pyupgrade` followed by unused
imports removal (thanks to `flake8` check).

Refs: https://pypi.org/project/pyupgrade/

Closes #203

Signed-off-by: Mike Fiedler <miketheman@gmail.com>