### PR TITLE
fix: enable `colspan` and `rowspan` attributes

### DIFF
--- a/readme_renderer/clean.py
+++ b/readme_renderer/clean.py
@@ -46,7 +46,7 @@ ALLOWED_ATTRIBUTES = {
     "img": ["src", "width", "height", "alt", "align", "class"],
     "span": ["class"],
     "th": ["align"],
-    "td": ["align"],
+    "td": ["align", "colspan", "rowspan"],
     "div": ["align", "class"],
     "h1": ["align"],
     "h2": ["align"],

--- a/tests/fixtures/test_rst_tables.html
+++ b/tests/fixtures/test_rst_tables.html
@@ -1,0 +1,62 @@
+<table>
+<colgroup>
+<col>
+<col>
+<col>
+<col>
+</colgroup>
+<thead>
+<tr><th>Header row, column 1
+(header rows optional)</th>
+<th>Header 2</th>
+<th>Header 3</th>
+<th>Header 4</th>
+</tr>
+</thead>
+<tbody>
+<tr><td>body row 1, column 1</td>
+<td>column 2</td>
+<td>column 3</td>
+<td>column 4</td>
+</tr>
+<tr><td>body row 2</td>
+<td colspan="3">Cells may span columns.</td>
+</tr>
+<tr><td>body row 3</td>
+<td rowspan="2">Cells may
+span rows.</td>
+<td colspan="2" rowspan="2"><ul>
+<li>Table cells</li>
+<li>contain</li>
+<li>body elements.</li>
+</ul>
+</td>
+</tr>
+<tr><td>body row 4</td>
+</tr>
+</tbody>
+</table>
+<table>
+<colgroup>
+<col>
+<col>
+</colgroup>
+<thead>
+<tr><th>title1</th>
+<th>title2</th>
+</tr>
+</thead>
+<tbody>
+<tr><td>col1</td>
+<td>col2</td>
+</tr>
+<tr><td rowspan="2">mutirow</td>
+<td>cell1</td>
+</tr>
+<tr><td>cell2</td>
+</tr>
+<tr><td>singlerow</td>
+<td>cell3</td>
+</tr>
+</tbody>
+</table>

--- a/tests/fixtures/test_rst_tables.rst
+++ b/tests/fixtures/test_rst_tables.rst
@@ -1,0 +1,28 @@
+.. Example from https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#tables
+
++------------------------+------------+----------+----------+
+| Header row, column 1   | Header 2   | Header 3 | Header 4 |
+| (header rows optional) |            |          |          |
++========================+============+==========+==========+
+| body row 1, column 1   | column 2   | column 3 | column 4 |
++------------------------+------------+----------+----------+
+| body row 2             | Cells may span columns.          |
++------------------------+------------+---------------------+
+| body row 3             | Cells may  | - Table cells       |
++------------------------+ span rows. | - contain           |
+| body row 4             |            | - body elements.    |
++------------------------+------------+---------------------+
+
+.. Example from #182
+
++---------------+---------------+
+| title1        | title2        |
++===============+===============+
+| col1          | col2          |
++---------------+---------------+
+| mutirow       | cell1         |
+|               +---------------+
+|               | cell2         |
++---------------+---------------+
+| singlerow     | cell3         |
++---------------+---------------+


### PR DESCRIPTION
Previously exlcuded directives made for incorrect rendering of rst table
cells spanning more than a single column or row.

Fixes #182

Signed-off-by: Mike Fiedler <miketheman@gmail.com>