### PR TITLE
fix: allow math in rst

### DIFF
--- a/readme_renderer/rst.py
+++ b/readme_renderer/rst.py
@@ -76,7 +76,8 @@ SETTINGS = {
 
     # Output math blocks as LaTeX that can be interpreted by MathJax for
     # a prettier display of Math formulas.
-    "math_output": "MathJax",
+    # Pass a dummy path to supress docutils warning and emit HTML.
+    "math_output": "MathJax /dummy.js",
 
     # Disable raw html as enabling it is a security risk, we do not want
     # people to be able to include any old HTML in the final output.

--- a/tests/fixtures/test_rst_math.html
+++ b/tests/fixtures/test_rst_math.html
@@ -1,0 +1,8 @@
+<p>A <tt>math</tt> directive:</p>
+<div class="math">
+\begin{equation*}
+\alpha _t(i) = P(O_1, O_2, \ldots  O_t, q_t = S_i \lambda )
+\end{equation*}
+</div>
+<p>A <tt>:math:</tt> role:</p>
+<p>The area of a circle is <span class="math">\(A_\text{c} = (\pi/4) d^2\)</span>.</p>

--- a/tests/fixtures/test_rst_math.rst
+++ b/tests/fixtures/test_rst_math.rst
@@ -1,0 +1,14 @@
+.. Sample from https://docutils.sourceforge.io/docs/ref/rst/directives.html#math
+
+A ``math`` directive:
+
+.. math::
+
+  α_t(i) = P(O_1, O_2, … O_t, q_t = S_i λ)
+
+
+.. Sample from https://docutils.sourceforge.io/docs/ref/rst/roles.html#math
+
+A ``:math:`` role:
+
+The area of a circle is :math:`A_\text{c} = (\pi/4) d^2`.


### PR DESCRIPTION
The first step to allowing math directives to be rendered on PyPI is
to enable the directive's warning to pass.

`docutils` tells us to pass a path to the `math_output` setting.
Since we `clean` the output, we can pass anything we want, as control
of the CSS will be handed on PyPI.

Refs: https://docutils.sourceforge.io/docs/user/config.html#math-output

This does **not** solve for Markdown math.

Resolves #115
Resolves #172

Once merged and released, I'll explore what it takes to get the MathJax JS working on the warehouse.