### PR TITLE
Multiple pyproject.toml fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "bleach>=2.1.0", "docutils>=0.13.1", "Pygments>=2.5.1"]
+requires = ["setuptools>=40.8.0"]
 build-backend = "setuptools.build_meta:__legacy__"
 
 # TODO: Remove when https://github.com/mgedmin/check-manifest/pull/155 released

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=40.8.0"]
-build-backend = "setuptools.build_meta:__legacy__"
+build-backend = "setuptools.build_meta"
 
 # TODO: Remove when https://github.com/mgedmin/check-manifest/pull/155 released
 [tool.check-manifest]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "bleach>=2.1.0", "docutils>=0.13.1", "Pygments>=2.5.1"]
+requires = ["setuptools>=40.8.0", "bleach>=2.1.0", "docutils>=0.13.1", "Pygments>=2.5.1"]
 build-backend = "setuptools.build_meta:__legacy__"
 
 # TODO: Remove when https://github.com/mgedmin/check-manifest/pull/155 released


### PR DESCRIPTION
1. Remove the redundant `wheel` requirement
2. Remove the incorrect build-time dependencies from `requires`
3. Use the correct setuptools backend