### PR TITLE
Add CLI option to render package README.

### DIFF
--- a/readme_renderer/__main__.py
+++ b/readme_renderer/__main__.py
@@ -1,29 +1,60 @@
 import argparse
 import email
-from readme_renderer.rst import render
+from readme_renderer.markdown import render as render_md
+from readme_renderer.rst import render as render_rst
+from readme_renderer.txt import render as render_txt
+import pathlib
 from pkg_resources import get_distribution
 import sys
 
 
 def __main__(args=None):
     parser = argparse.ArgumentParser(
-        description="Renders a .rst README to HTML",
+        description="Renders a .md, .rst, or .txt README to HTML",
     )
     parser.add_argument("-p", "--package", help="Get README from package metadata",
                         action="store_true")
+    parser.add_argument("-f", "--format", choices=["md", "rst", "txt"],
+                        help="README format (inferred from input file name or package)")
     parser.add_argument('input', help="Input README file or package name")
     parser.add_argument('-o', '--output', help="Output file (default: stdout)",
                         type=argparse.FileType('w'), default='-')
     args = parser.parse_args(args)
 
+    content_format = args.format
     if args.package:
         distribution = get_distribution(args.input)
         pkg_info = distribution.get_metadata(distribution.PKG_INFO)
         message = email.message_from_string(pkg_info)
         source = message.get_payload()
+
+        # Infer the format of the description from package metadata.
+        if not content_format:
+            content_type = message.get("Description-Content-Type", "text/x-rst")
+            if content_type == "text/x-rst":
+                content_format = "rst"
+            elif content_type == "text/markdown":
+                content_format = "md"
+            elif content_type == "text/plain":
+                content_format = "txt"
+            else:
+                raise ValueError(f"invalid content type {content_type} for package "
+                                 "`long_description`")
     else:
-        with open(args.input) as fp:
+        filename = pathlib.Path(args.input)
+        content_format = content_format or filename.suffix.lstrip(".")
+        with filename.open() as fp:
             source = fp.read()
+
+    if content_format == "md":
+        render = render_md
+    elif content_format == "rst":
+        render = render_rst
+    elif content_format == "txt":
+        render = render_txt
+    else:
+        raise ValueError(f"invalid README format: {content_format} (expected `md`, "
+                         "`rst`, or `txt`)")
     rendered = render(source, stream=sys.stderr)
     if rendered is None:
         sys.exit(1)

--- a/readme_renderer/__main__.py
+++ b/readme_renderer/__main__.py
@@ -1,19 +1,34 @@
 import argparse
+import email
 from readme_renderer.rst import render
+from pkg_resources import get_distribution
 import sys
 
 
-if __name__ == '__main__':
+def __main__(args=None):
     parser = argparse.ArgumentParser(
         description="Renders a .rst README to HTML",
     )
-    parser.add_argument('input', help="Input README file",
-                        type=argparse.FileType('r'))
+    parser.add_argument("-p", "--package", help="Get README from package metadata",
+                        action="store_true")
+    parser.add_argument('input', help="Input README file or package name")
     parser.add_argument('-o', '--output', help="Output file (default: stdout)",
                         type=argparse.FileType('w'), default='-')
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
-    rendered = render(args.input.read(), stream=sys.stderr)
+    if args.package:
+        distribution = get_distribution(args.input)
+        pkg_info = distribution.get_metadata(distribution.PKG_INFO)
+        message = email.message_from_string(pkg_info)
+        source = message.get_payload()
+    else:
+        with open(args.input) as fp:
+            source = fp.read()
+    rendered = render(source, stream=sys.stderr)
     if rendered is None:
         sys.exit(1)
     print(rendered, file=args.output)
+
+
+if __name__ == '__main__':
+    __main__()

--- a/readme_renderer/__main__.py
+++ b/readme_renderer/__main__.py
@@ -8,7 +8,7 @@ from pkg_resources import get_distribution
 import sys
 
 
-def __main__(args=None):
+def __main__(args=None):  # noqa: N807
     parser = argparse.ArgumentParser(
         description="Renders a .md, .rst, or .txt README to HTML",
     )

--- a/readme_renderer/__main__.py
+++ b/readme_renderer/__main__.py
@@ -6,9 +6,10 @@ from readme_renderer.txt import render as render_txt
 import pathlib
 from pkg_resources import get_distribution
 import sys
+from typing import Optional, List
 
 
-def __main__(args=None):  # noqa: N807
+def main(cli_args: Optional[List[str]] = None) -> None:
     parser = argparse.ArgumentParser(
         description="Renders a .md, .rst, or .txt README to HTML",
     )
@@ -19,7 +20,7 @@ def __main__(args=None):  # noqa: N807
     parser.add_argument('input', help="Input README file or package name")
     parser.add_argument('-o', '--output', help="Output file (default: stdout)",
                         type=argparse.FileType('w'), default='-')
-    args = parser.parse_args(args)
+    args = parser.parse_args(cli_args)
 
     content_format = args.format
     if args.package:
@@ -47,19 +48,18 @@ def __main__(args=None):  # noqa: N807
             source = fp.read()
 
     if content_format == "md":
-        render = render_md
+        rendered = render_md(source, stream=sys.stderr)
     elif content_format == "rst":
-        render = render_rst
+        rendered = render_rst(source, stream=sys.stderr)
     elif content_format == "txt":
-        render = render_txt
+        rendered = render_txt(source, stream=sys.stderr)
     else:
         raise ValueError(f"invalid README format: {content_format} (expected `md`, "
                          "`rst`, or `txt`)")
-    rendered = render(source, stream=sys.stderr)
     if rendered is None:
         sys.exit(1)
     print(rendered, file=args.output)
 
 
 if __name__ == '__main__':
-    __main__()
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,39 @@
+import pathlib
+import pytest
+from readme_renderer.__main__ import __main__
+import tempfile
+from unittest import mock
+
+
+@pytest.mark.parametrize("input_file", ["test_CommonMark_001.md", "test_rst_003.rst"])
+@pytest.mark.parametrize("output_file", [False, True])
+def test_cli_input_file(input_file, output_file):
+    input_file = pathlib.Path("tests/fixtures", input_file)
+
+    if output_file:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = pathlib.Path(tmpdir) / "output.html"
+            __main__(["-o", str(output), str(input_file)])
+            with output.open() as fp:
+                result = fp.read()
+    else:
+        with mock.patch("builtins.print") as print_:
+            __main__([str(input_file)])
+            print_.assert_called_once()
+            (result,), _ = print_.call_args
+
+    with input_file.with_suffix(".html").open() as fp:
+        expected = fp.read()
+    assert result.strip() == expected.strip()
+
+
+@pytest.mark.parametrize("package, contains", [
+    ("readme_renderer", "Readme Renderer is a library that will safely render"),
+    ("docutils", "Docutils is a modular system for processing documentation"),
+])
+def test_cli_package(package, contains):
+    with mock.patch("builtins.print") as print_:
+        __main__(["-p", package])
+        print_.assert_called_once()
+        (result,), _ = print_.call_args
+    assert contains in result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 import pathlib
 import pytest
-from readme_renderer.__main__ import __main__
+from readme_renderer.__main__ import main
 import tempfile
 from unittest import mock
 
@@ -16,12 +16,12 @@ def test_cli_input_file(input_file, output_file):
     if output_file:
         with tempfile.TemporaryDirectory() as tmpdir:
             output = pathlib.Path(tmpdir) / "output.html"
-            __main__(["-o", str(output), str(input_file)])
+            main(["-o", str(output), str(input_file)])
             with output.open() as fp:
                 result = fp.read()
     else:
         with mock.patch("builtins.print") as print_:
-            __main__([str(input_file)])
+            main([str(input_file)])
             print_.assert_called_once()
             (result,), _ = print_.call_args
 
@@ -33,7 +33,7 @@ def test_cli_input_file(input_file, output_file):
 def test_cli_invalid_format():
     with mock.patch("pathlib.Path.open"), \
             pytest.raises(ValueError, match="invalid README format: invalid"):
-        __main__(["no-file.invalid"])
+        main(["no-file.invalid"])
 
 
 def test_cli_explicit_format(input_file):
@@ -41,7 +41,7 @@ def test_cli_explicit_format(input_file):
     with input_file.open() as fp, \
             mock.patch("pathlib.Path.open", return_value=fp), \
             mock.patch("builtins.print") as print_:
-        __main__(["-f", fmt, "no-file.invalid"])
+        main(["-f", fmt, "no-file.invalid"])
         print_.assert_called_once()
         (result,), _ = print_.call_args
 
@@ -55,7 +55,7 @@ def test_cli_explicit_format(input_file):
 ])
 def test_cli_package(package, contains):
     with mock.patch("builtins.print") as print_:
-        __main__(["-p", package])
+        main(["-p", package])
         print_.assert_called_once()
         (result,), _ = print_.call_args
     assert contains in result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,21 +13,25 @@ def input_file(request):
 
 @pytest.mark.parametrize("output_file", [False, True])
 def test_cli_input_file(input_file, output_file):
-    if output_file:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            output = pathlib.Path(tmpdir) / "output.html"
-            main(["-o", str(output), str(input_file)])
-            with output.open() as fp:
-                result = fp.read()
-    else:
-        with mock.patch("builtins.print") as print_:
+    with mock.patch("builtins.print") as print_:
+        if output_file:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output = pathlib.Path(tmpdir) / "output.html"
+                main(["-o", str(output), str(input_file)])
+                with output.open() as fp:
+                    result = fp.read()
+        else:
             main([str(input_file)])
-            print_.assert_called_once()
-            (result,), _ = print_.call_args
+
+    print_.assert_called_once()
+    (result,), kwargs = print_.call_args
 
     with input_file.with_suffix(".html").open() as fp:
         expected = fp.read()
     assert result.strip() == expected.strip()
+
+    if output_file:
+        assert kwargs["file"].name == str(output)
 
 
 def test_cli_invalid_format():


### PR DESCRIPTION
This PR adds an option `--package` to the CLI such that the `README` of a package can be rendered as it would on `pypi.org`. Using this option, package authors can preview `README`s in addition to checking their validity using `twine check`. Rendering the `README` based on the package metadata is important because a number of packages strip out roles and directives that are not supported by `pypi.org` in their `setup.py`. Publishing to `test.pypi.org`, as discussed in pypa/twine#875, is an alternative, but having a local preview would be desirable (at least for myself). This PR also adds tests for the existing CLI.