### PR TITLE
Skip markdown tests if cmarkgfm is not installed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run tests
-        run: python -m tox -e py
+        run: |
+          python -m tox -e py
+          python -m tox -e noextra
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,11 @@ from unittest import mock
 @pytest.fixture(params=["test_CommonMark_001.md", "test_rst_003.rst",
                         "test_GFM_001.md", "test_txt_001.txt"])
 def input_file(request):
-    return pathlib.Path("tests/fixtures", request.param)
+    path = pathlib.Path("tests/fixtures", request.param)
+    # Skip markdown tests if the cmarkgfm optional dependency is not installed.
+    if path.suffix == ".md":
+        pytest.importorskip("cmarkgfm")
+    return path
 
 
 @pytest.mark.parametrize("output_file", [False, True])


### PR DESCRIPTION
Does what it says on the tin. Is this what you had in mind to close #275, @miketheman?