### PR TITLE
chore: drop support for python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["pypy-3.7", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["pypy-3.8", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@ tasks:
       # Upgrade pyenv itself
       pyenv update
 
-      export PY_VERSIONS="3.7 3.8 3.9 3.10 3.11"
+      export PY_VERSIONS="3.8 3.9 3.10 3.11"
 
       # Install all supported Python versions
       for py in $PY_VERSIONS;

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased  (???)
 -----------------
 
 * Test against Python 3.11, update listed support in classifiers
+* Drop support for Python 3.7
 
 37.3 (2022-10-31)
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setuptools.setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -60,5 +59,5 @@ setuptools.setup(
     include_package_data=True,
     extras_require={"md": "cmarkgfm>=0.8.0"},
     packages=setuptools.find_packages(exclude=["tests", "tests.*"]),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py311,pep8,packaging,noextra,mypy
+envlist = py38,py39,py310,py311,pep8,packaging,noextra,mypy
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Python 3.7 is no longer supported, so we can drop support here as well. Using the `python_requires` flag in the package metadata should guide installers on 3.7 to use the oldest published version (37.3).