### PR TITLE
add figcaption to allowed tags

### DIFF
--- a/readme_renderer/clean.py
+++ b/readme_renderer/clean.py
@@ -28,7 +28,7 @@ ALLOWED_TAGS = [
 
     # Custom Additions
     "br", "caption", "cite", "col", "colgroup", "dd", "del", "details", "div",
-    "dl", "dt", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "img", "p", "pre",
+    "dl", "dt", "figcaption", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "img", "p", "pre",
     "span", "sub", "summary", "sup", "table", "tbody", "td", "th", "thead",
     "tr", "tt", "kbd", "var", "input", "section", "aside", "nav", "s", "figure",
 ]

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setuptools.setup(
     version=about["__version__"],
     description=about["__summary__"],
     long_description=long_description,
+    long_description_content_type="text/x-rst",
     license=about["__license__"],
     url=about["__uri__"],
     author=about["__author__"],


### PR DESCRIPTION
fix #285

Hi,  
this pull requests adds the `figcaption` tag to the list of allowed tags.
I also added the missing `long_description_content_type` to the setup.py file as tox warned me about this.
Regards,  
Adrian