### PR TITLE
Update .gitpod.yml to replace deprecated extension

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -26,4 +26,4 @@ vscode:
   extensions:
     - ms-python.python
     - EditorConfig.EditorConfig
-    - bungcip.better-toml
+    - tamasfe.even-better-toml


### PR DESCRIPTION
When I open with Gitpod and see Better TOML extension has been deprecated, it is recommended to use the Even Better TOML extension instead.

![image](https://github.com/shenxianpeng/readme_renderer/assets/3353385/0f6fa329-dc96-491a-8efa-7433f447fa70)

More info come from https://github.com/bungcip/better-toml

> This repository is archieved. I currently don't have time to maintain this project anymore. I recommended to use https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml for better alternative.

Even Better TOML's feedback and installs look good.

![image](https://github.com/shenxianpeng/readme_renderer/assets/3353385/be9f0f88-172e-4264-903c-6ab248f8f80d)

