### PR TITLE
Exclude .gitpod.yml by default with check-manifest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,7 @@ Home-page = "https://github.com/pypa/readme_renderer"
 requires = ["setuptools>=40.8.0"]
 build-backend = "setuptools.build_meta"
 
-# TODO: Remove when https://github.com/mgedmin/check-manifest/pull/155 released
 [tool.check-manifest]
-ignore = [".gitpod.yml"]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ Home-page = "https://github.com/pypa/readme_renderer"
 requires = ["setuptools>=40.8.0"]
 build-backend = "setuptools.build_meta"
 
-[tool.check-manifest]
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
since https://github.com/mgedmin/check-manifest/pull/155 has been released, it's time to remove .gitpod.yml