### PR TITLE
Temporarily pin docutils to resolve CI failures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,12 @@ isolated_build = True
 
 [testenv]
 deps =
+    # This is a stopgap dependency pin.
+    # https://github.com/pypa/readme_renderer/issues/310
+    # This can be removed when Python 3.8 is no longer supported,
+    # or after the test suite is updated to resolve this issue.
+    docutils==0.20.1
+
     pytest
     pytest-cov
     pytest-icdiff


### PR DESCRIPTION
This PR introduces one possible route to resolve CI failures: pinning docutils to an older version that supports all of the Python versions that readme_renderer is currently tested against.

Newer versions of docutils changed the HTML rendering _and_ dropped Python 3.8 support, so the test suite currently only passes under Python 3.8, which is EOL in October 2024.

This PR is related to #310, but doesn't fundamentally resolve it. It does, however, allow evaluation of incoming PRs.