### PR TITLE
Lint specific directories

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,10 +28,11 @@ commands = mypy readme_renderer
 
 [testenv:pep8]
 basepython = python3
+skip_install = true
 deps =
     flake8
     pep8-naming
-commands = flake8 .
+commands = flake8 readme_renderer tests
 
 [testenv:packaging]
 deps =
@@ -48,6 +49,5 @@ basepython = python3
 extras =
 
 [flake8]
-exclude = .tox,*.egg
 select = E,W,F,N
 max-line-length = 88


### PR DESCRIPTION
My workflow includes creating a virtual environment in `.venv/` on both Linux and Windows and installing the package in editable mode. This causes `flake8 .` to churn through everything in the virtual environment and throw hundreds of errors.

This PR modifies the `flake8 .` lint command to target the project's code directories. It also configures the tox environment to skip building/installing the package, since it's unnecessary.