### PR TITLE
Skip installing the package when type linting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ extras = md
 
 [testenv:mypy]
 basepython = python3
+skip_install = true
 deps =
     mypy
     types-bleach


### PR DESCRIPTION
Mypy is configured to scan the source directory, not the installed package. Therefore, this PR configures tox to skip package installation.

On my machine, this change reduces the `mypy` tox run from 2.79 seconds to 0.25 seconds.