### PR TITLE
Lazy open output files, and always close them

### DIFF
--- a/readme_renderer/__main__.py
+++ b/readme_renderer/__main__.py
@@ -18,7 +18,7 @@ def main(cli_args: Optional[List[str]] = None) -> None:
                         help="README format (inferred from input file name or package)")
     parser.add_argument('input', help="Input README file or package name")
     parser.add_argument('-o', '--output', help="Output file (default: stdout)",
-                        type=argparse.FileType('w'), default='-')
+                        default='-')
     args = parser.parse_args(cli_args)
 
     content_format = args.format
@@ -55,7 +55,11 @@ def main(cli_args: Optional[List[str]] = None) -> None:
                          "`rst`, or `txt`)")
     if rendered is None:
         sys.exit(1)
-    print(rendered, file=args.output)
+    if args.output == "-":
+        print(rendered, file=sys.stdout)
+    else:
+        with open(args.output, "w") as fp:
+            print(rendered, file=fp)
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ setenv =
     # Display up to 20 frames in backtraces when showing ResourceWarnings.
     PYTHONTRACEMALLOC=20
 commands =
-    python -Wall -m pytest --strict-markers --cov {posargs}
+    pytest -Wall --strict-markers --cov {posargs}
 extras = md
 
 [testenv:mypy]

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,11 @@ deps =
     pytest
     pytest-cov
     pytest-icdiff
+setenv =
+    # Display up to 20 frames in backtraces when showing ResourceWarnings.
+    PYTHONTRACEMALLOC=20
 commands =
-    pytest --strict-markers --cov {posargs}
+    python -Wall -m pytest --strict-markers --cov {posargs}
 extras = md
 
 [testenv:mypy]


### PR DESCRIPTION
This PR modifies the test suite to show all warnings, including `ResourceWarning`. By doing so, this revealed that the CLI code never closes output files opened by `argparse` during argument parsing.

Therefore, this PR additionally modifies the CLI code to open output files _only when they will be written to_, and ensures that they are always closed after writing.