### PR TITLE
Support newer docutils versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["pypy-3.8", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version:
+          - "pypy-3.9"
+          - "pypy-3.10"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -29,7 +28,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
   "Typing :: Typed"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 md = ["cmarkgfm>=0.8.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,11 @@ authors = [
 ]
 readme = "README.rst"
 license = {text = "Apache License, Version 2.0"}
-dependencies = ["nh3>=0.2.14", "docutils>=0.13.1", "Pygments>=2.5.1"]
+dependencies = [
+  "nh3>=0.2.14",
+  "docutils>=0.21.2",
+  "Pygments>=2.5.1",
+]
 classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",

--- a/readme_renderer/clean.py
+++ b/readme_renderer/clean.py
@@ -26,7 +26,7 @@ ALLOWED_TAGS = {
     "br", "caption", "cite", "col", "colgroup", "dd", "del", "details", "div",
     "dl", "dt", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "img", "p", "pre",
     "span", "sub", "summary", "sup", "table", "tbody", "td", "th", "thead",
-    "tr", "tt", "kbd", "var", "input", "section", "aside", "nav", "s", "figure",
+    "tr", "tt", "kbd", "var", "input", "section", "aside", "nav", "figure",
     "figcaption", "picture",
 }
 

--- a/tests/fixtures/test_rst_bibtex.html
+++ b/tests/fixtures/test_rst_bibtex.html
@@ -1,2 +1,2 @@
 <pre><code><span class="nc">@article</span><span class="p">{</span><span class="nl">the_impact_of_pygments_docutils_config_and_html5</span><span class="p">,</span><span class="w">
-  </span><span class="na">year</span><span class="w"> </span><span class="p">=</span><span class="w"> </span><s>{2022}</s><span class="p">,</span></code></pre>
+  </span><span class="na">year</span><span class="w"> </span><span class="p">=</span><span class="w"> </span><span class="s">{2022}</span><span class="p">,</span></code></pre>

--- a/tests/fixtures/test_rst_contents.html
+++ b/tests/fixtures/test_rst_contents.html
@@ -1,5 +1,5 @@
 <nav class="contents" id="contents">
-<p class="topic-title">Contents</p>
+<p class="topic-title"><a href="#top" rel="nofollow">Contents</a></p>
 <ul class="simple">
 <li><p><a href="#features" id="toc-entry-1" rel="nofollow">Features</a></p></li>
 <li><p><a href="#installation" id="toc-entry-2" rel="nofollow">Installation</a></p></li>

--- a/tests/fixtures/test_rst_linkify.html
+++ b/tests/fixtures/test_rst_linkify.html
@@ -1,5 +1,9 @@
-<a href="https://travis-ci.org/tulsawebdevs/django-multi-gtfs" rel="nofollow"><img alt="https://travis-ci.org/tulsawebdevs/django-multi-gtfs.svg?branch=master" src="https://travis-ci.org/tulsawebdevs/django-multi-gtfs.svg?branch=master"></a>
-<a href="https://coveralls.io/github/tulsawebdevs/django-multi-gtfs" rel="nofollow"><img alt="https://coveralls.io/repos/github/tulsawebdevs/django-multi-gtfs/badge.svg?branch=django19" src="https://coveralls.io/repos/github/tulsawebdevs/django-multi-gtfs/badge.svg?branch=django19"></a>
+<a href="https://travis-ci.org/tulsawebdevs/django-multi-gtfs" rel="nofollow">
+<img alt="https://travis-ci.org/tulsawebdevs/django-multi-gtfs.svg?branch=master" src="https://travis-ci.org/tulsawebdevs/django-multi-gtfs.svg?branch=master">
+</a>
+<a href="https://coveralls.io/github/tulsawebdevs/django-multi-gtfs" rel="nofollow">
+<img alt="https://coveralls.io/repos/github/tulsawebdevs/django-multi-gtfs/badge.svg?branch=django19" src="https://coveralls.io/repos/github/tulsawebdevs/django-multi-gtfs/badge.svg?branch=django19">
+</a>
 <p><strong>multigtfs</strong> is an <a href="http://choosealicense.com/licenses/apache/" rel="nofollow">Apache 2.0</a>-licensed Django app that supports importing
 and exporting of GTFS feeds.  All features of the <a href="https://developers.google.com/transit/gtfs/reference" rel="nofollow">June 20, 2012 reference</a>
 are supported, including <a href="https://developers.google.com/transit/gtfs/changes#RevisionHistory" rel="nofollow">all changes</a> up to February 17, 2014.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,11 @@
 [tox]
-envlist = py38,py39,py310,py311,py312,pep8,packaging,noextra,mypy
+envlist =
+    py{39, 310, 311, 312}
+    pypy{39, 310}
+    pep8
+    packaging
+    noextra
+    mypy
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
This PR introduces the following changes, based on feedback in #310:

* Drop support for Python 3.8

  _(Newer docutils releases drop support for Python 3.8 *and* change how some test files render)_

* Require docutils 0.21.2 or higher
* Update three HTML test files to match how docutils 0.21.2 now renders the accompanying input files
* Test all supported CPython and PyPy versions in tox and in CI
* Remove `<s>` from the list of allowed HTML tags, now that newer docutils versions don't render that tag anymore

Fixes #310 

> [!NOTE]
>
> If this merges, #311 can be closed.