### PR TITLE
feat: support python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@ tasks:
       # Upgrade pyenv itself
       pyenv update
 
-      export PY_VERSIONS="3.8 3.9 3.10 3.11 3.12"
+      export PY_VERSIONS="3.8 3.9 3.10 3.11 3.12 3.13"
 
       # Install all supported Python versions
       for py in $PY_VERSIONS;

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@ tasks:
       # Upgrade pyenv itself
       pyenv update
 
-      export PY_VERSIONS="3.8 3.9 3.10 3.11 3.12 3.13"
+      export PY_VERSIONS="3.9 3.10 3.11 3.12 3.13"
 
       # Install all supported Python versions
       for py in $PY_VERSIONS;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Typing :: Typed"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39, 310, 311, 312}
+    py{39, 310, 311, 312, 313}
     pypy{39, 310}
     pep8
     packaging


### PR DESCRIPTION
Since Python 3.13 was officially released on October 7, 2024. Do you need to support it?