### PR TITLE
fix: update test outputs to fix tests fail

### DIFF
--- a/tests/fixtures/test_CommonMark_008.html
+++ b/tests/fixtures/test_CommonMark_008.html
@@ -1,9 +1,9 @@
 <p>Here is some Python code for a <code>Dog</code>:</p>
-<pre lang="python3"><span class="k">class</span> <span class="nc">Dog</span><span class="p">(</span><span class="n">Animal</span><span class="p">):</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">):</span>
+<pre lang="python3"><span class="k">class</span><span class="w"> </span><span class="nc">Dog</span><span class="p">(</span><span class="n">Animal</span><span class="p">):</span>
+    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">):</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 
-    <span class="k">def</span> <span class="nf">make_sound</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span><span class="w"> </span><span class="nf">make_sound</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="nb">print</span><span class="p">(</span><span class="s1">'Ruff!'</span><span class="p">)</span>
 
 <span class="n">dog</span> <span class="o">=</span> <span class="n">Dog</span><span class="p">(</span><span class="s1">'Fido'</span><span class="p">)</span>

--- a/tests/fixtures/test_GFM_doublequotes.html
+++ b/tests/fixtures/test_GFM_doublequotes.html
@@ -1,7 +1,7 @@
 <p>This is normal text.</p>
 <pre><code>This is code text.
 </code></pre>
-<pre lang="python3"><span class="k">def</span> <span class="nf">this_is_python</span><span class="p">():</span>
+<pre lang="python3"><span class="k">def</span><span class="w"> </span><span class="nf">this_is_python</span><span class="p">():</span>
 <span class="w">    </span><span class="sd">"""This is a docstring."""</span>
     <span class="k">pass</span>
 </pre>

--- a/tests/fixtures/test_GFM_highlight.html
+++ b/tests/fixtures/test_GFM_highlight.html
@@ -1,7 +1,7 @@
 <p>This is normal text.</p>
 <pre><code>This is code text.
 </code></pre>
-<pre lang="python3"><span class="k">def</span> <span class="nf">this_is_python</span><span class="p">():</span>
+<pre lang="python3"><span class="k">def</span><span class="w"> </span><span class="nf">this_is_python</span><span class="p">():</span>
     <span class="k">pass</span>
 </pre>
 <pre lang="go"><span class="kd">func</span><span class="w"> </span><span class="nx">ThisIsGo</span><span class="p">(){</span>

--- a/tests/fixtures/test_GFM_highlight_default_py.html
+++ b/tests/fixtures/test_GFM_highlight_default_py.html
@@ -1,4 +1,4 @@
-<pre lang="python3"><span class="k">async</span> <span class="k">def</span> <span class="nf">this_is_python</span><span class="p">():</span>
+<pre lang="python3"><span class="k">async</span> <span class="k">def</span><span class="w"> </span><span class="nf">this_is_python</span><span class="p">():</span>
     <span class="k">pass</span>
 
 <span class="nb">print</span><span class="p">(</span><span class="k">await</span> <span class="n">this_is_python</span><span class="p">())</span>

--- a/tests/fixtures/test_GFM_malicious_pre.html
+++ b/tests/fixtures/test_GFM_malicious_pre.html
@@ -1,5 +1,5 @@
 <p>This is normal text.</p>
-<pre lang="python3"><span class="k">def</span> <span class="nf">this_is_python</span><span class="p">():</span>
+<pre lang="python3"><span class="k">def</span><span class="w"> </span><span class="nf">this_is_python</span><span class="p">():</span>
 <span class="w">    </span><span class="sd">"""This is a docstring."""</span>
     <span class="k">pass</span>
 <span class="o">&lt;</span><span class="n">script</span> <span class="nb">type</span><span class="o">=</span><span class="s2">"text/javascript"</span><span class="o">&gt;</span><span class="n">alert</span><span class="p">(</span><span class="s1">'I am evil.'</span><span class="p">);</span><span class="o">&lt;/</span><span class="n">script</span><span class="o">&gt;</span>

--- a/tests/fixtures/test_rst_008.html
+++ b/tests/fixtures/test_rst_008.html
@@ -1,9 +1,9 @@
 <p>Here is some Python code for a <span class="docutils literal">Dog</span>:</p>
-<pre><code><span class="k">class</span> <span class="nc">Dog</span><span class="p">(</span><span class="n">Animal</span><span class="p">):</span><span class="w">
-</span>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">):</span><span class="w">
+<pre><code><span class="k">class</span><span class="w"> </span><span class="nc">Dog</span><span class="p">(</span><span class="n">Animal</span><span class="p">):</span><span class="w">
+</span>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">):</span><span class="w">
 </span>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span><span class="w">
 
-</span>    <span class="k">def</span> <span class="nf">make_sound</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span><span class="w">
+</span>    <span class="k">def</span><span class="w"> </span><span class="nf">make_sound</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span><span class="w">
 </span>        <span class="nb">print</span><span class="p">(</span><span class="s1">'Ruff!'</span><span class="p">)</span><span class="w">
 
 </span><span class="n">dog</span> <span class="o">=</span> <span class="n">Dog</span><span class="p">(</span><span class="s1">'Fido'</span><span class="p">)</span></code></pre>


### PR DESCRIPTION
Since Pygments [2.19.0](https://github.com/pygments/pygments/releases/tag/2.19.0), test failures have been occurring. Based on the suggestion from https://github.com/pypa/readme_renderer/pull/324#issuecomment-2599040997, updating the test outputs can resolve the issue.