### PR TITLE
Resolve mypy type annotation issues in CI

### DIFF
--- a/readme_renderer/rst.py
+++ b/readme_renderer/rst.py
@@ -13,24 +13,24 @@
 # limitations under the License.
 
 import io
-from typing import Any, Dict, IO, Optional, Union
+from typing import Any, Dict, IO, Optional
 
 from docutils.core import publish_parts
-from docutils.nodes import colspec, image
+from docutils.nodes import Element
 from docutils.writers.html5_polyglot import HTMLTranslator, Writer
 from docutils.utils import SystemMessage
 
 from .clean import clean
 
 
-class ReadMeHTMLTranslator(HTMLTranslator):  # type: ignore[misc] # docutils is incomplete, returns `Any` python/typeshed#7256 # noqa E501
+class ReadMeHTMLTranslator(HTMLTranslator):
 
     # Overrides base class not to output `<object>` tag for SVG images.
     object_image_types: Dict[str, str] = {}
 
     def emptytag(
         self,
-        node: Union[colspec, image],
+        node: Element,
         tagname: str,
         suffix: str = "\n",
         **attributes: Any


### PR DESCRIPTION
[Recent example of a mypy CI failure](https://github.com/pypa/readme_renderer/actions/runs/16498060479/job/46648725847#step:6:24):

> ```
> readme_renderer/rst.py:26: error: Unused "type: ignore" comment  [unused-ignore]
> readme_renderer/rst.py:33: error: Argument 1 of "emptytag" is incompatible with supertype "docutils.writers._html_base.HTMLTranslator"; supertype defines the argument type as "Element"  [override]
> readme_renderer/rst.py:33: note: This violates the Liskov substitution principle
> readme_renderer/rst.py:33: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
> ```

The CI failures appear to be related to an updated release of `types-docutils`.