### PR TITLE
Apply ruff/pyupgrade rules (UP)

### DIFF
--- a/readme_renderer/__main__.py
+++ b/readme_renderer/__main__.py
@@ -5,10 +5,10 @@ from readme_renderer.txt import render as render_txt
 import pathlib
 from importlib.metadata import metadata
 import sys
-from typing import Optional, List
+from typing import Optional
 
 
-def main(cli_args: Optional[List[str]] = None) -> None:
+def main(cli_args: Optional[list[str]] = None) -> None:
     parser = argparse.ArgumentParser(
         description="Renders a .md, .rst, or .txt README to HTML",
     )

--- a/readme_renderer/clean.py
+++ b/readme_renderer/clean.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Optional, Set
+from typing import Optional
 
 import nh3
 
@@ -67,8 +67,8 @@ ALLOWED_ATTRIBUTES = {
 
 def clean(
     html: str,
-    tags: Optional[Set[str]] = None,
-    attributes: Optional[Dict[str, Set[str]]] = None
+    tags: Optional[set[str]] = None,
+    attributes: Optional[dict[str, set[str]]] = None
 ) -> Optional[str]:
     if tags is None:
         tags = ALLOWED_TAGS

--- a/readme_renderer/markdown.py
+++ b/readme_renderer/markdown.py
@@ -14,7 +14,9 @@
 
 import re
 import warnings
-from typing import cast, Any, Callable, Match, Optional
+from typing import cast, Any, Optional
+from collections.abc import Callable
+from re import Match
 
 from html import unescape
 

--- a/readme_renderer/markdown.py
+++ b/readme_renderer/markdown.py
@@ -14,7 +14,7 @@
 
 import re
 import warnings
-from typing import cast, Any, Dict, Callable, Match, Optional
+from typing import cast, Any, Callable, Match, Optional
 
 from html import unescape
 
@@ -43,7 +43,7 @@ try:
     common_render_options = comrak.RenderOptions()
     common_render_options.unsafe_ = True  # handled by nh3
 
-    variants: Dict[str, Callable[[str], str]] = {
+    variants: dict[str, Callable[[str], str]] = {
         "GFM": lambda raw: cast(
             str,
             comrak.render_markdown(

--- a/readme_renderer/rst.py
+++ b/readme_renderer/rst.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import io
-from typing import Any, Dict, IO, Optional
+from typing import Any, IO, Optional
 
 from docutils.core import publish_parts
 from docutils.nodes import Element
@@ -26,7 +26,7 @@ from .clean import clean
 class ReadMeHTMLTranslator(HTMLTranslator):
 
     # Overrides base class not to output `<object>` tag for SVG images.
-    object_image_types: Dict[str, str] = {}
+    object_image_types: dict[str, str] = {}
 
     def emptytag(
         self,


### PR DESCRIPTION
I would suggest testing with ruff in addition to, or instead of flake8. This prepares such a change.

~~Requires #328 and #332 to pass CI tests.~~