### PR TITLE
Migrate license configuration from setup.cfg to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 readme = "README.rst"
 license = "Apache-2.0"
+license-files = ["LICENSE"]
 dependencies = [
   "nh3>=0.2.14",
   "docutils>=0.21.2",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-license_files = LICENSE


### PR DESCRIPTION
This PR removes the legacy `setup.cfg` file and moves license configuration to `pyproject.toml`, using the modern [PEP 621](https://peps.python.org/pep-0621/) – compliant metadata field [license-files](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-files).