### PR TITLE
chore: update supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "pypy-3.9"
-          - "pypy-3.10"
           - "pypy-3.11"
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -34,7 +33,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
   "Typing :: Typed"
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 md = ["cmarkgfm>=0.8.0"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{39, 310, 311, 312, 313, 314}
-    pypy{39, 310, 311}
+    py{310, 311, 312, 313, 314}
+    pypy{311}
     pep8
     packaging
     noextra


### PR DESCRIPTION
- Python 3.9 is no longer supported
- PyPy 3.11 is the only currently supported version

Refs: https://peps.python.org/pep-0596/#lifespan
Refs: https://github.com/pypa/readme_renderer/pull/334#issuecomment-3452610198