### PR TITLE
chore(ci): prevent double actions run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   test:
     name: Test - ${{ matrix.python-version }}


### PR DESCRIPTION
When branches are pushed to the main repo (like a dependabot automated branch), prevent double actions execution.