### PR TITLE
Fix RST definition list classifiers rendering without separators

### DIFF
--- a/readme_renderer/rst.py
+++ b/readme_renderer/rst.py
@@ -46,6 +46,16 @@ class ReadMeHTMLTranslator(HTMLTranslator):
             node, tagname, suffix, **attributes
         )
 
+    def visit_classifier(self, node: Any) -> None:
+        """Add colon and space before classifier span.
+        This overrides the default behavior to insert a visual separator
+        (colon and spaces) that would normally be added via CSS ::before,
+        ensuring the classifier is properly separated from the term even
+        without CSS support.
+        """
+        self.body.append(' : ')
+        super().visit_classifier(node)
+
 
 SETTINGS = {
     # Cloaking email addresses provides a small amount of additional

--- a/tests/fixtures/test_rst_deflist.html
+++ b/tests/fixtures/test_rst_deflist.html
@@ -1,0 +1,8 @@
+<dl class="simple">
+<dt>term : <span class="classifier">classifier</span></dt>
+<dd><p>Definition</p>
+</dd>
+<dt>term without classifier</dt>
+<dd><p>Another definition</p>
+</dd>
+</dl>

--- a/tests/fixtures/test_rst_deflist.rst
+++ b/tests/fixtures/test_rst_deflist.rst
@@ -1,0 +1,5 @@
+term : classifier
+    Definition
+
+term without classifier
+    Another definition


### PR DESCRIPTION
Fixes #317

**Problem**
Definition list classifiers like `term : classifier` were rendered as "termclassifier" on PyPI because the colon separator is normally added via CSS, which isn't available in PyPI's rendering context.

**Solution**
Override `visit_classifier()` in `ReadMeHTMLTranslator` to insert `:` directly into the HTML output.
