### PR TITLE
fix(rst): render classifier delimiter in definition lists

### DIFF
--- a/readme_renderer/rst.py
+++ b/readme_renderer/rst.py
@@ -46,6 +46,10 @@ class ReadMeHTMLTranslator(HTMLTranslator):
             node, tagname, suffix, **attributes
         )
 
+    def visit_classifier(self, node: Element) -> None:
+        self.body.append(' <span class="classifier-delimiter">:</span> ')
+        self.body.append(self.starttag(node, "span", "", CLASS="classifier"))
+
 
 SETTINGS = {
     # Cloaking email addresses provides a small amount of additional

--- a/tests/fixtures/test_rst_definition_list_classifier.html
+++ b/tests/fixtures/test_rst_definition_list_classifier.html
@@ -1,0 +1,5 @@
+<dl class="simple">
+<dt>term <span class="classifier-delimiter">:</span> <span class="classifier">classifier</span></dt>
+<dd><p>Definition</p>
+</dd>
+</dl>

--- a/tests/fixtures/test_rst_definition_list_classifier.rst
+++ b/tests/fixtures/test_rst_definition_list_classifier.rst
@@ -1,0 +1,3 @@
+term : classifier
+    Definition
+


### PR DESCRIPTION
Fixes #317.

Docutils html5 output omits the classifier delimiter for definition list terms (e.g. `term : classifier`), resulting in concatenated text like `termclassifier`.

This PR restores the delimiter to match the html4 writer output and adds a fixture regression test.