### PR TITLE
Use well-known labels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ include-package-data = true
 exclude = ["tests", "tests.*"]
 
 [project.urls]
-Home-page = "https://github.com/pypa/readme_renderer"
+Homepage = "https://github.com/pypa/readme_renderer"
 
 [build-system]
 requires = ["setuptools>=77.0.3"]


### PR DESCRIPTION
See:
* [PEP 753 – Uniform project URLs in core metadata](https://peps.python.org/pep-0753/)
* [Well-known Project URLs in Metadata](https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels)
* [Home-page](https://packaging.python.org/en/latest/specifications/core-metadata/#home-page)