### PR TITLE
Fix CLI --package flag for Python 3.15+

### DIFF
--- a/readme_renderer/__main__.py
+++ b/readme_renderer/__main__.py
@@ -24,7 +24,7 @@ def main(cli_args: Optional[list[str]] = None) -> None:
     content_format = args.format
     if args.package:
         message = metadata(args.input)
-        source = message.get_payload()  # type: ignore[attr-defined] # noqa: E501 https://peps.python.org/pep-0566/
+        source = message.get("Description") or message.get_payload()  # type: ignore[attr-defined] # noqa: E501 https://peps.python.org/pep-0566/
 
         # Infer the format of the description from package metadata.
         if not content_format:


### PR DESCRIPTION
Python 3.15 synced importlib.metadata with importlib_metadata 8.7, which stores the package description in the Description header field instead of the message payload. Try the Description header first, falling back to get_payload() for older Python versions.

Assisted-by: Cursor