### PR TITLE
Restrict OIDC token to publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,9 @@ on:
 permissions: {}
 
 jobs:
-  build-and-publish:
+  build:
+    name: Build distributions
     runs-on: ubuntu-latest
-    permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -26,5 +24,24 @@ jobs:
       run: pip install -U setuptools wheel build
     - name: Build
       run: python -m build .
+    - name: Upload distributions
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: distributions
+        path: dist/
+
+  publish:
+    name: Publish distributions to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+    - name: Download distributions
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: distributions
+        path: dist/
     - name: Publish
       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
The GH OIDC token used for Trusted Publishing should not be available to non-publishing steps. This PR removes it from the steps that install the dependencies and build the project, so that it's only available during PyPI publishing.