### PR TITLE
Fix ignored allowlists on `clean()`

### DIFF
--- a/readme_renderer/clean.py
+++ b/readme_renderer/clean.py
@@ -76,8 +76,8 @@ def clean(
     try:
         cleaned = nh3.clean(
             html,
-            tags=ALLOWED_TAGS,
-            attributes=ALLOWED_ATTRIBUTES,
+            tags=tags,
+            attributes=attributes,
             link_rel="nofollow",
             url_schemes={"http", "https", "mailto"},
         )

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -5,3 +5,17 @@ def test_invalid_link():
     assert clean(
         '<a href="http://exam](ple.com">foo</a>'
     ) == '<a rel="nofollow">foo</a>'
+
+
+def test_custom_tags_are_respected():
+    assert clean(
+        "<p>plain text</p><br><strong>bold text</strong>",
+        tags={"br"},
+    ) == "plain text<br>bold text"
+
+
+def test_custom_attributes_are_respected():
+    assert clean(
+        '<img src="https://example.com/image.png" alt="image" width="100">',
+        attributes={"img": {"alt"}},
+    ) == '<img alt="image">'


### PR DESCRIPTION
Custom tags and attributes passed to `clean()` were ignored and always replaced by the default values. This PR fixes that

cc @miketheman 