### PR TITLE
test: handle expected warnings

### DIFF
--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,8 +1,27 @@
+import contextlib
 from pathlib import Path
 
 import pytest
 
 from readme_renderer.markdown import render, variants
+
+
+def expect_extra_warning() -> contextlib.nullcontext | pytest.WarningsRecorder:
+    """Expect the missing-extra ``UserWarning`` only when it actually fires.
+
+    ``render()`` warns that "Markdown renderers are not available"
+    only when the optional ``md`` extra is not installed.
+    When the extra is present the same calls run silently,
+    so an unconditional ``pytest.warns`` would fail there.
+    Returning ``pytest.warns`` only on the ``noextra`` platform
+    keeps expected warnings out of the test summary on both,
+    and asserts the warning when it is genuinely expected.
+    """
+    if variants:
+        return contextlib.nullcontext()
+    return pytest.warns(
+        UserWarning, match="Markdown renderers are not available"
+    )
 
 
 @pytest.mark.parametrize(
@@ -26,4 +45,5 @@ def test_md_fixtures(md_filename, html_filename, variant):
 
 
 def test_missing_variant():
-    assert render('Hello', variant="InvalidVariant") is None
+    with expect_extra_warning():
+        assert render('Hello', variant="InvalidVariant") is None

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,11 @@ commands =
 [testenv:noextra]
 basepython = python3
 extras =
+# Without the `md` extra, importing readme_renderer.markdown warns at
+# collection time. That warning can't be wrapped in pytest.warns, so append a
+# filter that silences just it (a later -W wins) while reusing the base command.
+commands =
+    {[testenv]commands} -W "ignore:Markdown renderers are not available:UserWarning:readme_renderer.markdown"
 
 [testenv:resourcewarnings]
 description = run tests with resource warnings enabled, slower but useful to catch leaks


### PR DESCRIPTION
We know that these warnings are expected when the markdown extras are not installed.

Refs: #222