### PR TITLE
fix: unify admonition HTML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-md = ["comrak>=0.0.11"]
+md = ["comrak>=0.0.13"]
 
 [tool.setuptools]
 include-package-data = true

--- a/readme_renderer/__main__.py
+++ b/readme_renderer/__main__.py
@@ -1,10 +1,11 @@
 import argparse
+import pathlib
+import sys
+from importlib.metadata import metadata
+
 from readme_renderer.markdown import render as render_md
 from readme_renderer.rst import render as render_rst
 from readme_renderer.txt import render as render_txt
-import pathlib
-from importlib.metadata import metadata
-import sys
 
 
 def main(cli_args: list[str] | None = None) -> None:

--- a/readme_renderer/clean.py
+++ b/readme_renderer/clean.py
@@ -14,7 +14,6 @@
 
 import nh3
 
-
 ALLOWED_TAGS = {
     # Bleach Defaults
     "a", "abbr", "acronym", "b", "blockquote", "code", "em", "i", "li", "ol",

--- a/readme_renderer/markdown.py
+++ b/readme_renderer/markdown.py
@@ -19,6 +19,7 @@ from collections.abc import Callable
 from re import Match
 
 from html import unescape
+from html.parser import HTMLParser
 
 import pygments
 import pygments.lexers
@@ -94,10 +95,14 @@ def render(
     if not rendered:
         return None
 
-    # GFM uses header_ids which prefixes generated IDs. We need to also
-    # prefix relative links so they correctly point to those IDs.
     if variant == "GFM":
+        # GFM uses header_ids which prefixes generated IDs. We need to also
+        # prefix relative links so they correctly point to those IDs.
         rendered = _prefix_relative_links(rendered, _HEADER_ID_PREFIX)
+        # Comrak's HTML output doesn't match docutils's so we unify them.
+        # Can be replaced with an option once comrak supports this output:
+        # https://github.com/kivikakk/comrak/issues/821
+        rendered = _rewrite_gfm_alerts(rendered)
 
     highlighted = _highlight(rendered)
     cleaned = clean(highlighted)
@@ -149,6 +154,82 @@ def _highlight(html: str) -> str:
     result = code_expr.sub(replacer, html)
 
     return result
+
+
+def _rewrite_gfm_alerts(html: str) -> str:
+    r"""Rewrites GFM alert ``<div>``\ s into docutils-style ``<aside>``\ s.
+
+    Args:
+        html: The rendered HTML.
+
+    Returns:
+        The HTML with GFM alerts rewritten as admonitions.
+    """
+    rewriter = _GFMAlertRewriter()
+    rewriter.feed(html)
+    rewriter.close()
+    return "".join(rewriter.out)
+
+
+class _GFMAlertRewriter(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self.out: list[str] = []
+        # Tracks (original_tag, emitted_tag) for each open start tag,
+        # so a later end tag can be rewritten to match (e.g. div -> aside).
+        self._stack: list[tuple[str, str]] = []
+
+    def _emit_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> str:
+        classes = (dict(attrs).get("class") or "").split()
+
+        if tag == "div" and "markdown-alert" in classes:
+            alert_type = next((
+                c.removeprefix("markdown-alert-")
+                for c in classes
+                if c.startswith("markdown-alert-")
+            ), None)
+            if alert_type is not None:
+                self.out.append(f'<aside class="admonition {alert_type}">')
+                return "aside"
+
+        if tag == "p" and "markdown-alert-title" in classes:
+            self.out.append('<p class="admonition-title">')
+            return "p"
+
+        self.out.append(self.get_starttag_text() or f"<{tag}>")
+        return tag
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        emitted = self._emit_starttag(tag, attrs)
+        self._stack.append((tag, emitted))
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        self.out.append(self.get_starttag_text() or f"<{tag}/>")
+
+    def handle_endtag(self, tag: str) -> None:
+        # Find matching start tag while ignoring unclosed/void tags
+        for i, (t, emitted) in reversed(list(enumerate(self._stack))):
+            if t == tag:
+                del self._stack[i:]
+                self.out.append(f"</{emitted}>")
+                return
+        self.out.append(f"</{tag}>")
+
+    def handle_data(self, data: str) -> None:
+        self.out.append(data)
+
+    def handle_entityref(self, name: str) -> None:
+        self.out.append(f"&{name};")
+
+    def handle_charref(self, name: str) -> None:
+        self.out.append(f"&#{name};")
+
+    def handle_comment(self, data: str) -> None:
+        self.out.append(f"<!--{data}-->")
 
 
 def _prefix_relative_links(html: str, prefix: str) -> str:

--- a/readme_renderer/markdown.py
+++ b/readme_renderer/markdown.py
@@ -19,7 +19,6 @@ from collections.abc import Callable
 from re import Match
 
 from html import unescape
-from html.parser import HTMLParser
 
 import pygments
 import pygments.lexers
@@ -52,6 +51,7 @@ try:
 
     common_render_options = comrak.RenderOptions()
     common_render_options.unsafe_ = True  # handled by nh3
+    common_render_options.alert_style = comrak.AlertStyle.Semantic
 
     variants: dict[str, Callable[[str], str]] = {
         "GFM": lambda raw: cast(
@@ -95,14 +95,10 @@ def render(
     if not rendered:
         return None
 
+    # GFM uses header_ids which prefixes generated IDs. We need to also
+    # prefix relative links so they correctly point to those IDs.
     if variant == "GFM":
-        # GFM uses header_ids which prefixes generated IDs. We need to also
-        # prefix relative links so they correctly point to those IDs.
         rendered = _prefix_relative_links(rendered, _HEADER_ID_PREFIX)
-        # Comrak's HTML output doesn't match docutils's so we unify them.
-        # Can be replaced with an option once comrak supports this output:
-        # https://github.com/kivikakk/comrak/issues/821
-        rendered = _rewrite_gfm_alerts(rendered)
 
     highlighted = _highlight(rendered)
     cleaned = clean(highlighted)
@@ -154,82 +150,6 @@ def _highlight(html: str) -> str:
     result = code_expr.sub(replacer, html)
 
     return result
-
-
-def _rewrite_gfm_alerts(html: str) -> str:
-    r"""Rewrites GFM alert ``<div>``\ s into docutils-style ``<aside>``\ s.
-
-    Args:
-        html: The rendered HTML.
-
-    Returns:
-        The HTML with GFM alerts rewritten as admonitions.
-    """
-    rewriter = _GFMAlertRewriter()
-    rewriter.feed(html)
-    rewriter.close()
-    return "".join(rewriter.out)
-
-
-class _GFMAlertRewriter(HTMLParser):
-    def __init__(self) -> None:
-        super().__init__(convert_charrefs=False)
-        self.out: list[str] = []
-        # Tracks (original_tag, emitted_tag) for each open start tag,
-        # so a later end tag can be rewritten to match (e.g. div -> aside).
-        self._stack: list[tuple[str, str]] = []
-
-    def _emit_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> str:
-        classes = (dict(attrs).get("class") or "").split()
-
-        if tag == "div" and "markdown-alert" in classes:
-            alert_type = next((
-                c.removeprefix("markdown-alert-")
-                for c in classes
-                if c.startswith("markdown-alert-")
-            ), None)
-            if alert_type is not None:
-                self.out.append(f'<aside class="admonition {alert_type}">')
-                return "aside"
-
-        if tag == "p" and "markdown-alert-title" in classes:
-            self.out.append('<p class="admonition-title">')
-            return "p"
-
-        self.out.append(self.get_starttag_text() or f"<{tag}>")
-        return tag
-
-    def handle_starttag(
-        self, tag: str, attrs: list[tuple[str, str | None]]
-    ) -> None:
-        emitted = self._emit_starttag(tag, attrs)
-        self._stack.append((tag, emitted))
-
-    def handle_startendtag(
-        self, tag: str, attrs: list[tuple[str, str | None]]
-    ) -> None:
-        self.out.append(self.get_starttag_text() or f"<{tag}/>")
-
-    def handle_endtag(self, tag: str) -> None:
-        # Find matching start tag while ignoring unclosed/void tags
-        for i, (t, emitted) in reversed(list(enumerate(self._stack))):
-            if t == tag:
-                del self._stack[i:]
-                self.out.append(f"</{emitted}>")
-                return
-        self.out.append(f"</{tag}>")
-
-    def handle_data(self, data: str) -> None:
-        self.out.append(data)
-
-    def handle_entityref(self, name: str) -> None:
-        self.out.append(f"&{name};")
-
-    def handle_charref(self, name: str) -> None:
-        self.out.append(f"&#{name};")
-
-    def handle_comment(self, data: str) -> None:
-        self.out.append(f"<!--{data}-->")
 
 
 def _prefix_relative_links(html: str, prefix: str) -> str:

--- a/readme_renderer/markdown.py
+++ b/readme_renderer/markdown.py
@@ -14,15 +14,14 @@
 
 import re
 import warnings
-from typing import cast, Any
 from collections.abc import Callable
-from re import Match
-
 from html import unescape
+from re import Match
+from typing import Any, cast
 
 import pygments
-import pygments.lexers
 import pygments.formatters
+import pygments.lexers
 
 from .clean import clean
 

--- a/readme_renderer/rst.py
+++ b/readme_renderer/rst.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 import io
-from typing import Any, ClassVar, IO
+from typing import IO, Any, ClassVar
 
 from docutils.core import publish_parts
 from docutils.nodes import Element
-from docutils.writers.html5_polyglot import HTMLTranslator, Writer
 from docutils.utils import SystemMessage
+from docutils.writers.html5_polyglot import HTMLTranslator, Writer
 
 from .clean import clean
 
@@ -54,7 +54,7 @@ class ReadMeHTMLTranslator(HTMLTranslator):
         Skip the probe so the image renders at natural size
         instead of aborting render.
         """
-        return None
+        return
 
 
 SETTINGS = {

--- a/readme_renderer/txt.py
+++ b/readme_renderer/txt.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from html import escape as html_escape
 from typing import Any
 
 from .clean import clean
-
-from html import escape as html_escape
 
 
 def render(raw: str, **kwargs: Any) -> str | None:

--- a/tests/fixtures/test_GFM_alerts.html
+++ b/tests/fixtures/test_GFM_alerts.html
@@ -1,23 +1,23 @@
 <h1><a href="#user-content-github-alerts" id="user-content-github-alerts" rel="nofollow"></a>GitHub Alerts</h1>
 <p>Also known as callouts and admonitions.</p>
-<div class="markdown-alert markdown-alert-note">
-<p class="markdown-alert-title">Note</p>
+<aside class="admonition note">
+<p class="admonition-title">Note</p>
 <p>Useful information that users should know, even when skimming content.</p>
-</div>
-<div class="markdown-alert markdown-alert-tip">
-<p class="markdown-alert-title">Tip</p>
+</aside>
+<aside class="admonition tip">
+<p class="admonition-title">Tip</p>
 <p>Helpful advice for doing things better or more easily.</p>
-</div>
-<div class="markdown-alert markdown-alert-important">
-<p class="markdown-alert-title">Important</p>
+</aside>
+<aside class="admonition important">
+<p class="admonition-title">Important</p>
 <p>Key information users need to know to achieve their goal.</p>
-</div>
-<div class="markdown-alert markdown-alert-warning">
-<p class="markdown-alert-title">Warning</p>
+</aside>
+<aside class="admonition warning">
+<p class="admonition-title">Warning</p>
 <p>Urgent info that needs immediate user attention to avoid problems.</p>
-</div>
-<div class="markdown-alert markdown-alert-caution">
-<p class="markdown-alert-title">Caution</p>
+</aside>
+<aside class="admonition caution">
+<p class="admonition-title">Caution</p>
 <p>Advises about risks or negative outcomes of certain actions.</p>
-</div>
+</aside>
 <p><a href="https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts" rel="nofollow">Source reference</a></p>

--- a/tests/fixtures/test_GFM_alerts.html
+++ b/tests/fixtures/test_GFM_alerts.html
@@ -1,4 +1,4 @@
-<h1><a href="#user-content-github-alerts" id="user-content-github-alerts" rel="nofollow"></a>GitHub Alerts</h1>
+<h1 id="user-content-github-alerts">GitHub Alerts<a href="#user-content-github-alerts" rel="nofollow"></a></h1>
 <p>Also known as callouts and admonitions.</p>
 <aside class="admonition note">
 <p class="admonition-title">Note</p>

--- a/tests/fixtures/test_GFM_emoji.html
+++ b/tests/fixtures/test_GFM_emoji.html
@@ -1,4 +1,4 @@
-<h1><a href="#user-content-github-emoji" id="user-content-github-emoji" rel="nofollow"></a>GitHub Emoji</h1>
+<h1 id="user-content-github-emoji">GitHub Emoji<a href="#user-content-github-emoji" rel="nofollow"></a></h1>
 <p>Wow, 👍 I like this! 🎉 ✨</p>
 <p><code>:shipit:</code> and other custom GitHub emoji are not yet supported and will render as :shipit:
 <a href="https://github.com/rossmacarthur/emojis/issues/32" rel="nofollow">Track this issue</a> for updates.</p>

--- a/tests/fixtures/test_GFM_headings.html
+++ b/tests/fixtures/test_GFM_headings.html
@@ -1,14 +1,14 @@
-<h1><a href="#user-content-heading-1" id="user-content-heading-1" rel="nofollow"></a>Heading 1</h1>
+<h1 id="user-content-heading-1">Heading 1<a href="#user-content-heading-1" rel="nofollow"></a></h1>
 <p>Some text</p>
-<h2><a href="#user-content-heading-2" id="user-content-heading-2" rel="nofollow"></a>Heading 2</h2>
+<h2 id="user-content-heading-2">Heading 2<a href="#user-content-heading-2" rel="nofollow"></a></h2>
 <p>Lorem ipsum dolor sit amet consectetur adipiscing elit.</p>
-<h3><a href="#user-content-heading-3" id="user-content-heading-3" rel="nofollow"></a>Heading 3</h3>
+<h3 id="user-content-heading-3">Heading 3<a href="#user-content-heading-3" rel="nofollow"></a></h3>
 <p>Lorem ipsum dolor sit amet consectetur adipiscing elit.</p>
-<h4><a href="#user-content-heading-4" id="user-content-heading-4" rel="nofollow"></a>Heading 4</h4>
+<h4 id="user-content-heading-4">Heading 4<a href="#user-content-heading-4" rel="nofollow"></a></h4>
 <p>Lorem ipsum dolor sit amet consectetur adipiscing elit.</p>
-<h5><a href="#user-content-heading-5" id="user-content-heading-5" rel="nofollow"></a>Heading 5</h5>
+<h5 id="user-content-heading-5">Heading 5<a href="#user-content-heading-5" rel="nofollow"></a></h5>
 <p>Lorem ipsum dolor sit amet consectetur adipiscing elit.</p>
-<h6><a href="#user-content-heading-6" id="user-content-heading-6" rel="nofollow"></a>Heading 6</h6>
+<h6 id="user-content-heading-6">Heading 6<a href="#user-content-heading-6" rel="nofollow"></a></h6>
 <p>Lorem ipsum dolor sit amet consectetur adipiscing elit.</p>
 <hr>
 <p>Relative links to <a href="#user-content-heading-2" rel="nofollow">Heading 2</a> and <a href="#user-content-heading-4" rel="nofollow">Heading 4</a></p>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,10 @@
 import pathlib
-import pytest
-from readme_renderer.__main__ import main
 import tempfile
 from unittest import mock
+
+import pytest
+
+from readme_renderer.__main__ import main
 
 
 @pytest.fixture(params=["test_CommonMark_001.md", "test_rst_003.rst",


### PR DESCRIPTION
fixes #378

should be quite straightforward and robust:
- If tag names and classes match the two known tags emitted by comrak, we replace start and end tags with the desired HTML
- When handling the end tag, we just skip void (self-closing) tags that don’t match until we find a match. This makes it robust against HTML5 adding new void tags
- `self.get_starttag_text()` is used for unhandled tags, which means we can’t make mistakes re-emitting them

The only thing I’m unsure about is that we don’t handle declarations (`<!`) and processing instructions (`<?`): should we do that?